### PR TITLE
Add recall latest assessment scores for new assessments

### DIFF
--- a/backend/src/main/java/com/batal/controller/AssessmentController.java
+++ b/backend/src/main/java/com/batal/controller/AssessmentController.java
@@ -223,6 +223,32 @@ public class AssessmentController {
         }
     }
 
+    // ===== LATEST SCORES =====
+
+    /**
+     * Get the latest skill scores for a player to pre-fill new assessments.
+     * Returns scores from the most recent assessment, or defaults (score 1) for first-time players.
+     */
+    @GetMapping("/player/{playerId}/latest-scores")
+    public ResponseEntity<?> getLatestScoresForPlayer(@PathVariable Long playerId) {
+        try {
+            LatestSkillScoresResponse response = assessmentService.getLatestScoresForPlayer(playerId);
+            return ResponseEntity.ok(response);
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of(
+                "error", "Forbidden",
+                "message", "Access denied",
+                "status", 403
+            ));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
+                "error", "Not Found",
+                "message", e.getMessage(),
+                "status", 404
+            ));
+        }
+    }
+
     // ===== ANALYTICS OPERATIONS =====
 
     /**

--- a/backend/src/main/java/com/batal/dto/LatestSkillScoresResponse.java
+++ b/backend/src/main/java/com/batal/dto/LatestSkillScoresResponse.java
@@ -1,0 +1,65 @@
+package com.batal.dto;
+
+import com.batal.entity.enums.SkillCategory;
+import java.time.LocalDate;
+import java.util.List;
+
+public class LatestSkillScoresResponse {
+
+    private boolean isFirstAssessment;
+    private LocalDate lastAssessmentDate;
+    private List<SkillScoreEntry> skillScores;
+
+    public LatestSkillScoresResponse() {}
+
+    public LatestSkillScoresResponse(boolean isFirstAssessment, LocalDate lastAssessmentDate,
+                                     List<SkillScoreEntry> skillScores) {
+        this.isFirstAssessment = isFirstAssessment;
+        this.lastAssessmentDate = lastAssessmentDate;
+        this.skillScores = skillScores;
+    }
+
+    public static class SkillScoreEntry {
+        private Long skillId;
+        private String skillName;
+        private SkillCategory skillCategory;
+        private int score;
+        private String notes;
+
+        public SkillScoreEntry() {}
+
+        public SkillScoreEntry(Long skillId, String skillName, SkillCategory skillCategory,
+                               int score, String notes) {
+            this.skillId = skillId;
+            this.skillName = skillName;
+            this.skillCategory = skillCategory;
+            this.score = score;
+            this.notes = notes;
+        }
+
+        public Long getSkillId() { return skillId; }
+        public void setSkillId(Long skillId) { this.skillId = skillId; }
+
+        public String getSkillName() { return skillName; }
+        public void setSkillName(String skillName) { this.skillName = skillName; }
+
+        public SkillCategory getSkillCategory() { return skillCategory; }
+        public void setSkillCategory(SkillCategory skillCategory) { this.skillCategory = skillCategory; }
+
+        public int getScore() { return score; }
+        public void setScore(int score) { this.score = score; }
+
+        public String getNotes() { return notes; }
+        public void setNotes(String notes) { this.notes = notes; }
+    }
+
+    // Getters and Setters
+    public boolean getIsFirstAssessment() { return isFirstAssessment; }
+    public void setIsFirstAssessment(boolean isFirstAssessment) { this.isFirstAssessment = isFirstAssessment; }
+
+    public LocalDate getLastAssessmentDate() { return lastAssessmentDate; }
+    public void setLastAssessmentDate(LocalDate lastAssessmentDate) { this.lastAssessmentDate = lastAssessmentDate; }
+
+    public List<SkillScoreEntry> getSkillScores() { return skillScores; }
+    public void setSkillScores(List<SkillScoreEntry> skillScores) { this.skillScores = skillScores; }
+}

--- a/backend/src/main/java/com/batal/dto/LatestSkillScoresResponse.java
+++ b/backend/src/main/java/com/batal/dto/LatestSkillScoresResponse.java
@@ -1,6 +1,7 @@
 package com.batal.dto;
 
 import com.batal.entity.enums.SkillCategory;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -54,6 +55,7 @@ public class LatestSkillScoresResponse {
     }
 
     // Getters and Setters
+    @JsonProperty("isFirstAssessment")
     public boolean getIsFirstAssessment() { return isFirstAssessment; }
     public void setIsFirstAssessment(boolean isFirstAssessment) { this.isFirstAssessment = isFirstAssessment; }
 

--- a/backend/src/main/java/com/batal/repository/AssessmentRepository.java
+++ b/backend/src/main/java/com/batal/repository/AssessmentRepository.java
@@ -59,25 +59,25 @@ public interface AssessmentRepository extends JpaRepository<Assessment, Long> {
     @Query("SELECT COUNT(a) FROM Assessment a WHERE a.assessor = :assessor")
     long countByAssessor(@Param("assessor") User assessor);
     
-    // Duplicate prevention methods (using Player ID)
+    // Duplicate prevention methods (using Player ID with portable date-range comparisons)
     @Query("SELECT a FROM Assessment a WHERE a.player.id = :playerId AND " +
-           "YEAR(a.assessmentDate) = :year AND MONTH(a.assessmentDate) = :month")
-    List<Assessment> findByPlayerIdAndYearAndMonth(@Param("playerId") Long playerId, 
-                                                 @Param("year") int year, 
-                                                 @Param("month") int month);
-    
+           "a.assessmentDate >= :startOfMonth AND a.assessmentDate < :startOfNextMonth")
+    List<Assessment> findByPlayerIdAndMonth(@Param("playerId") Long playerId,
+                                           @Param("startOfMonth") LocalDate startOfMonth,
+                                           @Param("startOfNextMonth") LocalDate startOfNextMonth);
+
     @Query("SELECT COUNT(a) > 0 FROM Assessment a WHERE a.player.id = :playerId AND " +
-           "YEAR(a.assessmentDate) = :year AND MONTH(a.assessmentDate) = :month")
-    boolean existsByPlayerIdAndYearAndMonth(@Param("playerId") Long playerId, 
-                                          @Param("year") int year, 
-                                          @Param("month") int month);
-    
+           "a.assessmentDate >= :startOfMonth AND a.assessmentDate < :startOfNextMonth")
+    boolean existsByPlayerIdInMonth(@Param("playerId") Long playerId,
+                                   @Param("startOfMonth") LocalDate startOfMonth,
+                                   @Param("startOfNextMonth") LocalDate startOfNextMonth);
+
     @Query("SELECT COUNT(a) > 0 FROM Assessment a WHERE a.player.id = :playerId AND " +
-           "YEAR(a.assessmentDate) = :year AND MONTH(a.assessmentDate) = :month AND a.id != :assessmentId")
-    boolean existsByPlayerIdAndYearAndMonthAndIdNot(@Param("playerId") Long playerId, 
-                                                  @Param("year") int year, 
-                                                  @Param("month") int month, 
-                                                  @Param("assessmentId") Long assessmentId);
+           "a.assessmentDate >= :startOfMonth AND a.assessmentDate < :startOfNextMonth AND a.id != :assessmentId")
+    boolean existsByPlayerIdInMonthExcluding(@Param("playerId") Long playerId,
+                                            @Param("startOfMonth") LocalDate startOfMonth,
+                                            @Param("startOfNextMonth") LocalDate startOfNextMonth,
+                                            @Param("assessmentId") Long assessmentId);
     
     List<Assessment> findByAssessorIdOrderByAssessmentDateDesc(Long assessorId);
     

--- a/backend/src/main/java/com/batal/repository/AssessmentRepository.java
+++ b/backend/src/main/java/com/batal/repository/AssessmentRepository.java
@@ -101,4 +101,13 @@ public interface AssessmentRepository extends JpaRepository<Assessment, Long> {
            "LEFT JOIN FETCH ss.skill " +
            "WHERE a.id = :assessmentId")
     Optional<Assessment> findByIdWithAllRelations(@Param("assessmentId") Long assessmentId);
+
+    // Fetch the most recent assessment for a player with skill scores eagerly loaded
+    @Query("SELECT a FROM Assessment a " +
+            "LEFT JOIN FETCH a.skillScores ss " +
+            "LEFT JOIN FETCH ss.skill " +
+            "WHERE a.player.id = :playerId " +
+            "ORDER BY a.assessmentDate DESC " +
+            "LIMIT 1")
+    Optional<Assessment> findLatestByPlayerIdWithSkillScores(@Param("playerId") Long playerId);
 }

--- a/backend/src/main/java/com/batal/service/AssessmentService.java
+++ b/backend/src/main/java/com/batal/service/AssessmentService.java
@@ -53,7 +53,7 @@ public class AssessmentService {
         validateCoachCanAssessPlayer(currentUser, player.getUser());
 
         // Check for duplicate assessments in the same month
-        validateNoDuplicateAssessment(player.getUser(), request.getAssessmentDate(), null);
+        validateNoDuplicateAssessment(player, request.getAssessmentDate(), null);
 
         // Validate skills belong to player's level
         validateSkillsForPlayerLevel(request.getSkillRatings(), player.getUser().getLevel());
@@ -177,7 +177,7 @@ public class AssessmentService {
         // Validate no duplicate if date is being changed
         if (request.getAssessmentDate() != null && 
             !request.getAssessmentDate().equals(assessment.getAssessmentDate())) {
-            validateNoDuplicateAssessment(assessment.getPlayer().getUser(), request.getAssessmentDate(), assessmentId);
+            validateNoDuplicateAssessment(assessment.getPlayer(), request.getAssessmentDate(), assessmentId);
         }
 
         // Update fields
@@ -533,23 +533,23 @@ public class AssessmentService {
         throw new SecurityException("Access denied to edit this assessment");
     }
 
-    private void validateNoDuplicateAssessment(User player, LocalDate assessmentDate, Long excludeAssessmentId) {
-        int year = assessmentDate.getYear();
-        int month = assessmentDate.getMonthValue();
-        
+    private void validateNoDuplicateAssessment(Player player, LocalDate assessmentDate, Long excludeAssessmentId) {
+        LocalDate startOfMonth = assessmentDate.withDayOfMonth(1);
+        LocalDate startOfNextMonth = startOfMonth.plusMonths(1);
+
         boolean exists;
         if (excludeAssessmentId != null) {
-            exists = assessmentRepository.existsByPlayerIdAndYearAndMonthAndIdNot(
-                player.getId(), year, month, excludeAssessmentId);
+            exists = assessmentRepository.existsByPlayerIdInMonthExcluding(
+                player.getId(), startOfMonth, startOfNextMonth, excludeAssessmentId);
         } else {
-            exists = assessmentRepository.existsByPlayerIdAndYearAndMonth(
-                player.getId(), year, month);
+            exists = assessmentRepository.existsByPlayerIdInMonth(
+                player.getId(), startOfMonth, startOfNextMonth);
         }
-        
+
         if (exists) {
             throw new IllegalStateException(
-                "An assessment already exists for this player in " + 
-                assessmentDate.getMonth() + " " + year);
+                "An assessment already exists for this player in " +
+                assessmentDate.getMonth() + " " + assessmentDate.getYear());
         }
     }
 

--- a/backend/src/main/java/com/batal/service/AssessmentService.java
+++ b/backend/src/main/java/com/batal/service/AssessmentService.java
@@ -382,6 +382,51 @@ public class AssessmentService {
         );
     }
 
+    // ===== LATEST SCORES =====
+
+    @PreAuthorize("hasRole('COACH') or hasRole('ADMIN') or hasRole('MANAGER')")
+    @Transactional(readOnly = true)
+    public LatestSkillScoresResponse getLatestScoresForPlayer(Long playerId) {
+        User currentUser = getCurrentAuthenticatedUser();
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new EntityNotFoundException("Player not found with ID: " + playerId));
+
+        validateCanViewPlayerAssessments(currentUser, player.getUser());
+
+        Optional<Assessment> latestAssessment = assessmentRepository.findLatestByPlayerIdWithSkillScores(playerId);
+
+        if (latestAssessment.isPresent()) {
+            Assessment assessment = latestAssessment.get();
+            List<LatestSkillScoresResponse.SkillScoreEntry> entries = assessment.getSkillScores().stream()
+                    .map(ss -> new LatestSkillScoresResponse.SkillScoreEntry(
+                            ss.getSkill().getId(),
+                            ss.getSkill().getName(),
+                            ss.getSkill().getCategory(),
+                            ss.getScore(),
+                            ss.getNotes()
+                    ))
+                    .collect(Collectors.toList());
+
+            return new LatestSkillScoresResponse(false, assessment.getAssessmentDate(), entries);
+        } else {
+            // First assessment — return all applicable skills with score 1
+            List<Skill> applicableSkills = skillRepository
+                    .findByApplicableLevelsContainingAndIsActiveTrue(player.getUser().getLevel());
+
+            List<LatestSkillScoresResponse.SkillScoreEntry> entries = applicableSkills.stream()
+                    .map(skill -> new LatestSkillScoresResponse.SkillScoreEntry(
+                            skill.getId(),
+                            skill.getName(),
+                            skill.getCategory(),
+                            1,
+                            null
+                    ))
+                    .collect(Collectors.toList());
+
+            return new LatestSkillScoresResponse(true, null, entries);
+        }
+    }
+
     // ===== HELPER METHODS =====
 
     private Assessment findAssessmentById(Long assessmentId) {
@@ -572,7 +617,7 @@ public class AssessmentService {
                     .orElseThrow(() -> new EntityNotFoundException("Skill not found with ID: " + rating.getSkillId()));
 
             // Get previous score if exists
-            Integer previousScore = getPreviousSkillScore(assessment.getPlayer().getUser(), skill);
+            Integer previousScore = getPreviousSkillScore(assessment.getPlayer(), skill);
 
             SkillScore skillScore = new SkillScore();
             skillScore.setAssessment(assessment);
@@ -607,7 +652,7 @@ public class AssessmentService {
                 existingScore.setNotes(rating.getNotes());
             } else {
                 // Create new skill score
-                Integer previousScore = getPreviousSkillScore(assessment.getPlayer().getUser(), skill);
+                Integer previousScore = getPreviousSkillScore(assessment.getPlayer(), skill);
 
                 SkillScore skillScore = new SkillScore();
                 skillScore.setAssessment(assessment);
@@ -631,10 +676,13 @@ public class AssessmentService {
         }
     }
 
-    private Integer getPreviousSkillScore(User player, Skill skill) {
-        // TODO: Update SkillScoreRepository to work with User entities
-        // For now, return null - previous scores will be calculated differently
-        return null;
+    private Integer getPreviousSkillScore(Player player, Skill skill) {
+        return assessmentRepository.findLatestByPlayerIdWithSkillScores(player.getId())
+                .flatMap(assessment -> assessment.getSkillScores().stream()
+                        .filter(ss -> ss.getSkill().getId().equals(skill.getId()))
+                        .map(SkillScore::getScore)
+                        .findFirst())
+                .orElse(null);
     }
 
     private void updateAssessmentFields(Assessment assessment, AssessmentUpdateRequest request) {

--- a/frontend/src/components/assessments/AssessmentForm.tsx
+++ b/frontend/src/components/assessments/AssessmentForm.tsx
@@ -138,7 +138,7 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
             const skillsForLevel = await skillsAPI.getSkillsForAssessment(player.level as any);
             setSkills(skillsForLevel);
 
-            // Initialize skill scores for new assessments or when player changes
+            // Initialize and pre-fill skill scores for new assessments
             if (isCreating || !assessment) {
               const initialScores: { [skillId: number]: SkillScoreFormData } = {};
               skillsForLevel.forEach(skill => {
@@ -148,6 +148,20 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
                   notes: ''
                 };
               });
+
+              // Pre-fill from latest assessment scores
+              try {
+                const latest = await assessmentsAPI.getLatestScores(player.id);
+                latest.skillScores.forEach(entry => {
+                  if (initialScores[entry.skillId]) {
+                    initialScores[entry.skillId].score = entry.score;
+                    initialScores[entry.skillId].notes = entry.notes || '';
+                  }
+                });
+              } catch (err) {
+                console.error('Failed to load latest scores for pre-fill:', err);
+              }
+
               setFormData(prev => ({ ...prev, skillScores: initialScores }));
             }
           } catch (err) {

--- a/frontend/src/lib/api/assessments.ts
+++ b/frontend/src/lib/api/assessments.ts
@@ -7,7 +7,8 @@ import {
   AssessmentFilters,
   AssessmentSummary,
   AssessmentHistory,
-  AssessmentPeriod
+  AssessmentPeriod,
+  LatestSkillScoresResponse
 } from '@/types/assessments';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api';
@@ -304,6 +305,16 @@ class AssessmentsAPI {
     });
     
     return this.handleResponse<Assessment[]>(response);
+  }
+
+  // Latest scores for pre-filling new assessments
+  async getLatestScores(playerId: number): Promise<LatestSkillScoresResponse> {
+    const response = await fetch(`${API_BASE}/assessments/player/${playerId}/latest-scores`, {
+      method: 'GET',
+      headers: await this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<LatestSkillScoresResponse>(response);
   }
 
   // Player-specific operations

--- a/frontend/src/types/assessments.ts
+++ b/frontend/src/types/assessments.ts
@@ -75,6 +75,21 @@ export interface AssessmentResponse {
   skillScores: SkillScore[];
 }
 
+// Latest scores response for pre-filling new assessments
+export interface LatestSkillScoresResponse {
+  isFirstAssessment: boolean;
+  lastAssessmentDate: string | null;
+  skillScores: LatestSkillScoreEntry[];
+}
+
+export interface LatestSkillScoreEntry {
+  skillId: number;
+  skillName: string;
+  skillCategory: SkillCategory;
+  score: number;
+  notes: string | null;
+}
+
 // UI specific types
 export interface AssessmentFormData {
   playerId: number | null;


### PR DESCRIPTION
## Summary
- Add `GET /assessments/player/{playerId}/latest-scores` endpoint that returns a player's most recent assessment scores for pre-filling new assessments
- For first-time players with no assessment history, all skills default to score 1
- Fix the `getPreviousSkillScore()` stub so `previousScore` and `improvement` fields are now automatically populated on new assessments
- Pre-fill the frontend assessment form when a coach selects a player, so they only need to adjust what changed

## Test plan
- [ ] API: Call `/assessments/player/{id}/latest-scores` for a player with existing assessments — returns latest scores with `isFirstAssessment: false`
- [ ] API: Call same endpoint for a player with no assessments — returns all applicable skills at score 1 with `isFirstAssessment: true`
- [ ] API: Verify existing endpoints (`/assessments/player/{id}`, `/assessments/my-assessments`) still work
- [ ] UI: Select an assessed player in the form — sliders pre-fill with latest scores
- [ ] UI: Select a new player — sliders default to 1
- [ ] Create a new assessment and verify `previousScore` and `improvement` are populated in the response