### PR TITLE
Add recall previous assessment scores feature

### DIFF
--- a/backend/src/main/java/com/batal/controller/AssessmentController.java
+++ b/backend/src/main/java/com/batal/controller/AssessmentController.java
@@ -240,6 +240,23 @@ public class AssessmentController {
         }
     }
 
+    // ===== LATEST SCORES =====
+
+    /**
+     * Get the latest finalized scores for a player (one score per skill)
+     */
+    @GetMapping("/player/{playerId}/latest-scores")
+    public ResponseEntity<Map<Long, Integer>> getLatestScoresForPlayer(@PathVariable Long playerId) {
+        try {
+            Map<Long, Integer> latestScores = assessmentService.getLatestScoresForPlayer(playerId);
+            return ResponseEntity.ok(latestScores);
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
     // ===== UTILITY ENDPOINTS =====
 
     /**

--- a/backend/src/main/java/com/batal/repository/SkillScoreRepository.java
+++ b/backend/src/main/java/com/batal/repository/SkillScoreRepository.java
@@ -17,5 +17,19 @@ import java.util.Optional;
 
 @Repository
 public interface SkillScoreRepository extends JpaRepository<SkillScore, Long> {
-    
+
+    @Query("SELECT ss.score FROM SkillScore ss JOIN ss.assessment a JOIN a.player p " +
+           "WHERE p.id = :playerId AND ss.skill.id = :skillId AND a.isFinalized = true " +
+           "ORDER BY a.assessmentDate DESC")
+    List<Integer> findPreviousScoresByPlayerAndSkill(@Param("playerId") Long playerId,
+                                                     @Param("skillId") Long skillId);
+
+    @Query("SELECT ss.skill.id, ss.score FROM SkillScore ss " +
+           "WHERE ss.assessment.id = (" +
+               "SELECT a.id FROM Assessment a " +
+               "WHERE a.player.id = :playerId AND a.isFinalized = true " +
+               "ORDER BY a.assessmentDate DESC LIMIT 1" +
+           ")")
+    List<Object[]> findLatestScoresByPlayerId(@Param("playerId") Long playerId);
+
 }

--- a/backend/src/main/java/com/batal/service/AssessmentService.java
+++ b/backend/src/main/java/com/batal/service/AssessmentService.java
@@ -382,6 +382,22 @@ public class AssessmentService {
         );
     }
 
+    // ===== LATEST SCORES =====
+
+    @PreAuthorize("hasRole('COACH') or hasRole('ADMIN') or hasRole('MANAGER')")
+    @Transactional(readOnly = true)
+    public Map<Long, Integer> getLatestScoresForPlayer(Long playerId) {
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new EntityNotFoundException("Player not found with ID: " + playerId));
+
+        List<Object[]> results = skillScoreRepository.findLatestScoresByPlayerId(playerId);
+        Map<Long, Integer> latestScores = new HashMap<>();
+        for (Object[] row : results) {
+            latestScores.put((Long) row[0], (Integer) row[1]);
+        }
+        return latestScores;
+    }
+
     // ===== HELPER METHODS =====
 
     private Assessment findAssessmentById(Long assessmentId) {
@@ -630,9 +646,8 @@ public class AssessmentService {
     }
 
     private Integer getPreviousSkillScore(Player player, Skill skill) {
-        // TODO: Update SkillScoreRepository to work with Player entities
-        // For now, return null - previous scores will be calculated differently
-        return null;
+        List<Integer> scores = skillScoreRepository.findPreviousScoresByPlayerAndSkill(player.getId(), skill.getId());
+        return scores.isEmpty() ? null : scores.get(0);
     }
 
     private void updateAssessmentFields(Assessment assessment, AssessmentUpdateRequest request) {

--- a/frontend/src/components/assessments/AssessmentForm.tsx
+++ b/frontend/src/components/assessments/AssessmentForm.tsx
@@ -58,6 +58,7 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [isDraft, setIsDraft] = useState(true);
   const [hasChanges, setHasChanges] = useState(false);
+  const [previousScores, setPreviousScores] = useState<Record<number, number>>({});
 
   const isReadOnly = mode === 'view' || (assessment?.isFinalized && mode !== 'create');
   const isEditing = mode === 'edit';
@@ -149,6 +150,17 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
                 };
               });
               setFormData(prev => ({ ...prev, skillScores: initialScores }));
+
+              // Fetch latest scores for previous assessment recall
+              if (isCreating) {
+                try {
+                  const latestScores = await assessmentsAPI.getLatestScores(player.id);
+                  setPreviousScores(latestScores);
+                } catch (err) {
+                  console.error('Failed to load previous scores:', err);
+                  setPreviousScores({});
+                }
+              }
             }
           } catch (err) {
             console.error('Failed to load skills for player level:', err);
@@ -159,6 +171,7 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
         // Clear skills and selected player when no player is selected
         setSelectedPlayer(null);
         setSkills([]);
+        setPreviousScores({});
         if (isCreating) {
           setFormData(prev => ({ ...prev, skillScores: {} }));
         }
@@ -450,6 +463,7 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
                           disabled={isReadOnly}
                           showDescription={false}
                           compact={true}
+                          previousScore={isCreating ? (previousScores[skill.id] ?? 1) : undefined}
                         />
                       ))}
                     </div>

--- a/frontend/src/components/assessments/SkillRatingInput.tsx
+++ b/frontend/src/components/assessments/SkillRatingInput.tsx
@@ -11,6 +11,7 @@ interface SkillRatingInputProps {
   disabled?: boolean;
   showDescription?: boolean;
   compact?: boolean;
+  previousScore?: number;
 }
 
 export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
@@ -19,7 +20,8 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
   onChange,
   disabled = false,
   showDescription = false,
-  compact = false
+  compact = false,
+  previousScore
 }) => {
   const [hoveredScore, setHoveredScore] = useState<number>(0);
 
@@ -54,6 +56,11 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
         <div className="flex items-center justify-between mb-2">
           <div className="flex-1 min-w-0">
             <h4 className="font-medium text-text-primary text-sm truncate">{skill.name}</h4>
+            {previousScore !== undefined && (
+              <span className="ml-2 px-1.5 py-0.5 bg-gray-100 text-gray-500 text-xs rounded flex-shrink-0">
+                Prev: {previousScore}
+              </span>
+            )}
             {showDescription && skill.description && (
               <p className="text-xs text-text-secondary mt-1 line-clamp-1">{skill.description}</p>
             )}
@@ -116,6 +123,11 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
         <div className="flex-1">
           <div className="flex items-center gap-3 mb-2">
             <h3 className="font-bold text-xl text-text-primary">{skill.name}</h3>
+            {previousScore !== undefined && (
+              <span className="px-2 py-0.5 bg-gray-100 text-gray-500 text-xs rounded-full">
+                Previous: {previousScore}
+              </span>
+            )}
             <div className={`
               px-3 py-1 rounded-full text-xs font-semibold transition-all
               ${currentScore > 0

--- a/frontend/src/lib/api/assessments.ts
+++ b/frontend/src/lib/api/assessments.ts
@@ -121,6 +121,15 @@ class AssessmentsAPI {
     return this.handleResponse<AssessmentSummary>(response);
   }
 
+  // Latest scores for previous assessment recall
+  async getLatestScores(playerId: number): Promise<Record<number, number>> {
+    const response = await fetch(`${API_BASE}/assessments/player/${playerId}/latest-scores`, {
+      method: 'GET',
+      headers: await this.getAuthHeaders(),
+    });
+    return this.handleResponse<Record<number, number>>(response);
+  }
+
   // Coach-specific operations
   async getCoachAssessments(): Promise<Assessment[]> {
     const response = await fetch(`${API_BASE}/assessments/my-assessments`, {

--- a/frontend/src/types/assessments.ts
+++ b/frontend/src/types/assessments.ts
@@ -32,6 +32,8 @@ export interface SkillScore {
   skillCategory: SkillCategory;
   score: number; // 1-10 scale
   notes?: string;
+  previousScore?: number;
+  improvement?: number;
 }
 
 // Request DTOs for API calls


### PR DESCRIPTION
## Summary
- Show previous skill scores as read-only reference when coaches create new assessments
- Coaches can see each skill's last finalized score (defaults to 1 for new players with no history)
- New `GET /assessments/player/{id}/latest-scores` endpoint returns latest finalized scores per skill

## Changes

### Backend
- **SkillScoreRepository**: Added JPQL queries for previous scores lookup (single skill + bulk by player)
- **AssessmentService**: Implemented `getPreviousSkillScore()` (was a TODO), added `getLatestScoresForPlayer()` method
- **AssessmentController**: Added `GET /assessments/player/{playerId}/latest-scores` endpoint

### Frontend
- **SkillScore type**: Added `previousScore` and `improvement` optional fields
- **AssessmentsAPI**: Added `getLatestScores(playerId)` client method
- **AssessmentForm**: Fetches previous scores when player selected in create mode, passes to skill inputs
- **SkillRatingInput**: Displays "Prev: N" badge (compact) / "Previous: N" badge (expanded) next to skill names

## Test plan
- [ ] Create a player and finalize a first assessment with various scores
- [ ] Call `GET /api/assessments/player/{id}/latest-scores` — should return finalized scores
- [ ] Open assessment creation form for same player — each skill shows "Previous: X" badge
- [ ] For a new player with no assessments, badges should show "Previous: 1"
- [ ] Verify changing player selection clears and reloads previous scores
- [ ] Backend compiles: `cd backend && ./mvnw compile`
- [ ] Frontend builds: `cd frontend && npm run build`