### PR TITLE
Merge parent and player creation into single flow

### DIFF
--- a/backend/src/main/java/com/batal/controller/PlayerController.java
+++ b/backend/src/main/java/com/batal/controller/PlayerController.java
@@ -76,8 +76,6 @@ public class PlayerController {
                 return "firstName";
             case "lastname":
                 return "lastName";
-            case "email":
-                return "email";
             case "fullname":
                 // For full name, we'll use firstName as the primary sort
                 return "firstName";

--- a/backend/src/main/java/com/batal/controller/UserController.java
+++ b/backend/src/main/java/com/batal/controller/UserController.java
@@ -142,6 +142,14 @@ public class UserController {
         return ResponseEntity.ok(availableCoaches);
     }
 
+    // GET /api/users/parents/search - Search parents by name or email
+    @GetMapping("/parents/search")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<List<UserResponse>> searchParents(@RequestParam String search) {
+        List<UserResponse> parents = userService.searchParents(search);
+        return ResponseEntity.ok(parents);
+    }
+
     // ========== PARENT-CHILD MANAGEMENT ENDPOINTS ==========
 
     // POST /api/users/{parentId}/children - Assign a child to a parent

--- a/backend/src/main/java/com/batal/dto/PlayerDTO.java
+++ b/backend/src/main/java/com/batal/dto/PlayerDTO.java
@@ -16,14 +16,6 @@ public class PlayerDTO {
     @Size(max = 100, message = "Last name must not exceed 100 characters")
     private String lastName;
     
-    @NotBlank(message = "Email is required")
-    @Email(message = "Email should be valid")
-    @Size(max = 255, message = "Email must not exceed 255 characters")
-    private String email;
-    
-    @Size(max = 20, message = "Phone must not exceed 20 characters")
-    private String phone;
-    
     private LocalDate dateOfBirth;
     
     private Gender gender;
@@ -32,6 +24,7 @@ public class PlayerDTO {
     private String address;
 
     // Parent relationship (computed from parent User entity)
+    @NotNull(message = "Parent is required")
     private Long parentId;
 
     @Size(max = 200, message = "Parent name must not exceed 200 characters")
@@ -72,10 +65,9 @@ public class PlayerDTO {
     // Constructors
     public PlayerDTO() {}
     
-    public PlayerDTO(String firstName, String lastName, String email, String parentName, Level level) {
+    public PlayerDTO(String firstName, String lastName, String parentName, Level level) {
         this.firstName = firstName;
         this.lastName = lastName;
-        this.email = email;
         this.parentName = parentName;
         this.level = level;
         this.isActive = true;
@@ -91,12 +83,6 @@ public class PlayerDTO {
     
     public String getLastName() { return lastName; }
     public void setLastName(String lastName) { this.lastName = lastName; }
-    
-    public String getEmail() { return email; }
-    public void setEmail(String email) { this.email = email; }
-    
-    public String getPhone() { return phone; }
-    public void setPhone(String phone) { this.phone = phone; }
     
     public LocalDate getDateOfBirth() { return dateOfBirth; }
     public void setDateOfBirth(LocalDate dateOfBirth) { this.dateOfBirth = dateOfBirth; }
@@ -163,7 +149,6 @@ public class PlayerDTO {
                 "id=" + id +
                 ", firstName='" + firstName + '\'' +
                 ", lastName='" + lastName + '\'' +
-                ", email='" + email + '\'' +
                 ", level=" + level +
                 ", isActive=" + isActive +
                 '}';

--- a/backend/src/main/java/com/batal/entity/Player.java
+++ b/backend/src/main/java/com/batal/entity/Player.java
@@ -4,7 +4,6 @@ import com.batal.entity.enums.Gender;
 import com.batal.entity.enums.Level;
 import com.batal.entity.enums.BasicFoot;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -35,12 +34,6 @@ public class Player {
     @NotBlank
     @Column(name = "last_name", nullable = false, length = 100)
     private String lastName;
-
-    @Email
-    @Column(unique = true, nullable = false)
-    private String email;
-
-    private String phone;
 
     @Column(name = "date_of_birth")
     private LocalDate dateOfBirth;
@@ -207,7 +200,6 @@ public class Player {
                 "id=" + id +
                 ", firstName='" + firstName + '\'' +
                 ", lastName='" + lastName + '\'' +
-                ", email='" + email + '\'' +
                 ", playerNumber='" + playerNumber + '\'' +
                 ", position='" + position + '\'' +
                 '}';

--- a/backend/src/main/java/com/batal/repository/PlayerRepository.java
+++ b/backend/src/main/java/com/batal/repository/PlayerRepository.java
@@ -14,12 +14,6 @@ import java.util.Optional;
 @Repository
 public interface PlayerRepository extends JpaRepository<Player, Long> {
 
-    // ========== EMAIL-BASED QUERIES ==========
-    boolean existsByEmail(String email);
-
-    @Query("SELECT p FROM Player p LEFT JOIN FETCH p.group WHERE p.email = :email")
-    Optional<Player> findByEmailWithGroup(@Param("email") String email);
-
     // ========== ID-BASED QUERIES WITH RELATIONSHIPS ==========
     @Query("SELECT p FROM Player p LEFT JOIN FETCH p.group WHERE p.id = :id")
     Optional<Player> findByIdWithGroup(@Param("id") Long id);
@@ -49,7 +43,6 @@ public interface PlayerRepository extends JpaRepository<Player, Long> {
     @Query("SELECT p FROM Player p LEFT JOIN FETCH p.group WHERE " +
             "LOWER(p.firstName) LIKE LOWER(CONCAT('%', :search, '%')) " +
             "OR LOWER(p.lastName) LIKE LOWER(CONCAT('%', :search, '%')) " +
-            "OR LOWER(p.email) LIKE LOWER(CONCAT('%', :search, '%')) " +
             "OR LOWER(CONCAT(p.firstName, ' ', p.lastName)) LIKE LOWER(CONCAT('%', :search, '%'))")
     Page<Player> findAllWithGroupAndSearch(@Param("search") String search, Pageable pageable);
 

--- a/backend/src/main/java/com/batal/repository/UserRepository.java
+++ b/backend/src/main/java/com/batal/repository/UserRepository.java
@@ -47,4 +47,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("SELECT COUNT(u) FROM User u JOIN u.roles r WHERE r.name = 'ADMIN' AND u.isActive = true")
     long countActiveAdminUsers();
 
+    @Query("SELECT u FROM User u WHERE u.userType = 'PARENT' AND (" +
+            "LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+            "OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+            "OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')) " +
+            "OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :search, '%')))")
+    List<User> searchParents(@Param("search") String search);
+
 }

--- a/backend/src/main/java/com/batal/service/ParentService.java
+++ b/backend/src/main/java/com/batal/service/ParentService.java
@@ -116,8 +116,6 @@ public class ParentService {
         dto.setId(player.getId());
         dto.setFirstName(player.getFirstName());
         dto.setLastName(player.getLastName());
-        dto.setEmail(player.getEmail());
-        dto.setPhone(player.getPhone());
         dto.setDateOfBirth(player.getDateOfBirth());
         dto.setGender(player.getGender());
         dto.setAddress(player.getAddress());

--- a/backend/src/main/java/com/batal/service/PlayerService.java
+++ b/backend/src/main/java/com/batal/service/PlayerService.java
@@ -50,22 +50,15 @@ public class PlayerService {
      * Create a new player with option for automatic group assignment
      */
     public PlayerDTO createPlayer(PlayerDTO playerDTO, boolean autoAssignGroup) {
-        // Check if email already exists
-        if (playerRepository.existsByEmail(playerDTO.getEmail())) {
-            throw new RuntimeException("Player with email " + playerDTO.getEmail() + " already exists");
-        }
-
-        // Check if user with this email already exists
-        if (userRepository.existsByEmail(playerDTO.getEmail())) {
-            throw new RuntimeException("User with email " + playerDTO.getEmail() + " already exists");
+        // Parent is required
+        if (playerDTO.getParentId() == null) {
+            throw new RuntimeException("Parent is required when creating a player");
         }
 
         // Create Player entity directly (no User needed - players don't authenticate)
         Player player = new Player();
         player.setFirstName(playerDTO.getFirstName());
         player.setLastName(playerDTO.getLastName());
-        player.setEmail(playerDTO.getEmail());
-        player.setPhone(playerDTO.getPhone());
         player.setDateOfBirth(playerDTO.getDateOfBirth());
         player.setGender(playerDTO.getGender());
         player.setAddress(playerDTO.getAddress());
@@ -80,18 +73,16 @@ public class PlayerService {
         player.setPlayerNumber(playerDTO.getPlayerNumber());
         player.setPosition(playerDTO.getPosition());
 
-        // Set parent if provided
-        if (playerDTO.getParentId() != null) {
-            User parent = userRepository.findById(playerDTO.getParentId())
-                    .orElseThrow(() -> new RuntimeException("Parent not found with id: " + playerDTO.getParentId()));
+        // Set parent (required)
+        User parent = userRepository.findById(playerDTO.getParentId())
+                .orElseThrow(() -> new RuntimeException("Parent not found with id: " + playerDTO.getParentId()));
 
-            // Validate parent is actually a PARENT user type
-            if (parent.getUserType() != UserType.PARENT) {
-                throw new RuntimeException("User with id " + playerDTO.getParentId() + " is not a parent");
-            }
-
-            player.setParent(parent);
+        // Validate parent is actually a PARENT user type
+        if (parent.getUserType() != UserType.PARENT) {
+            throw new RuntimeException("User with id " + playerDTO.getParentId() + " is not a parent");
         }
+
+        player.addParent(parent);
 
         // Set group if provided, otherwise auto-assign if enabled
         if (playerDTO.getGroupId() != null) {
@@ -156,26 +147,11 @@ public class PlayerService {
     }
 
     /**
-     * Get player by email
-     */
-    @Transactional(readOnly = true)
-    public Optional<PlayerDTO> getPlayerByEmail(String email) {
-        Optional<Player> player = playerRepository.findByEmailWithGroup(email);
-        return player.map(this::convertToDTO);
-    }
-
-    /**
      * Update player
      */
     public PlayerDTO updatePlayer(Long id, PlayerDTO playerDTO) {
         Player existingPlayer = playerRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Player not found with id: " + id));
-
-        // Check if email is being changed and if new email already exists
-        if (!existingPlayer.getEmail().equals(playerDTO.getEmail()) &&
-                playerRepository.existsByEmail(playerDTO.getEmail())) {
-            throw new RuntimeException("Player with email " + playerDTO.getEmail() + " already exists");
-        }
 
         // Update fields
         updatePlayerFields(existingPlayer, playerDTO);
@@ -378,8 +354,6 @@ public class PlayerService {
         // Get data directly from Player entity
         dto.setFirstName(player.getFirstName());
         dto.setLastName(player.getLastName());
-        dto.setEmail(player.getEmail());
-        dto.setPhone(player.getPhone());
         dto.setDateOfBirth(player.getDateOfBirth());
         dto.setGender(player.getGender());
         dto.setAddress(player.getAddress());
@@ -401,10 +375,11 @@ public class PlayerService {
             dto.setGroupName(player.getGroup().getName());
         }
 
-        // Set parent information
-        if (player.getParent() != null) {
-            dto.setParentId(player.getParent().getId());
-            dto.setParentName(player.getParent().getFullName());
+        // Set parent information (use first parent from many-to-many)
+        if (!player.getParents().isEmpty()) {
+            User firstParent = player.getParents().iterator().next();
+            dto.setParentId(firstParent.getId());
+            dto.setParentName(firstParent.getFullName());
         }
 
         dto.setCreatedAt(player.getCreatedAt());
@@ -430,8 +405,6 @@ public class PlayerService {
         // Update all fields directly on Player entity
         player.setFirstName(dto.getFirstName());
         player.setLastName(dto.getLastName());
-        player.setEmail(dto.getEmail());
-        player.setPhone(dto.getPhone());
         player.setDateOfBirth(dto.getDateOfBirth());
         player.setGender(dto.getGender());
         player.setAddress(dto.getAddress());
@@ -455,9 +428,11 @@ public class PlayerService {
                 throw new RuntimeException("User with id " + dto.getParentId() + " is not a parent");
             }
 
-            player.setParent(parent);
+            // Clear existing parents and add the new one
+            player.getParents().clear();
+            player.addParent(parent);
         } else {
-            player.setParent(null);  // Allow un-assigning parent
+            player.getParents().clear();
         }
 
         if (dto.getIsActive() != null) {

--- a/backend/src/main/java/com/batal/service/UserService.java
+++ b/backend/src/main/java/com/batal/service/UserService.java
@@ -369,6 +369,19 @@ public class UserService {
     }
 
     /**
+     * Search for parents by name or email
+     */
+    @Transactional(readOnly = true)
+    public List<UserResponse> searchParents(String search) {
+        List<User> parents = userRepository.searchParents(search);
+        return parents.stream()
+                .map(user -> new UserResponse(user, user.getRoles().stream()
+                        .map(Role::getName)
+                        .collect(Collectors.toList())))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Helper method to map Player entity to ChildSummaryDTO
      */
     private ChildSummaryDTO mapPlayerToChildSummary(Player player) {

--- a/backend/src/main/resources/db/migration/V44__Remove_player_email_phone.sql
+++ b/backend/src/main/resources/db/migration/V44__Remove_player_email_phone.sql
@@ -1,0 +1,10 @@
+-- Remove email and phone columns from players table
+-- Contact info should come from the parent User entity
+
+-- Drop unique constraint on email first
+ALTER TABLE players DROP CONSTRAINT IF EXISTS players_email_key;
+ALTER TABLE players ALTER COLUMN email DROP NOT NULL;
+
+-- Drop the columns
+ALTER TABLE players DROP COLUMN IF EXISTS email;
+ALTER TABLE players DROP COLUMN IF EXISTS phone;

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1063,7 +1063,7 @@ export default function AdminDashboard() {
                 <div className="relative">
                   <input
                     type="text"
-                    placeholder="Search players by name or email..."
+                    placeholder="Search players by name..."
                     value={playersPagination.search}
                     onChange={(e) => {
                       setPlayersPagination(prev => ({

--- a/frontend/src/components/AssignChildModal.tsx
+++ b/frontend/src/components/AssignChildModal.tsx
@@ -16,7 +16,6 @@ interface Player {
   id: number;
   firstName: string;
   lastName: string;
-  email: string;
   dateOfBirth?: string;
   groupName?: string;
   level?: string;
@@ -53,8 +52,7 @@ export default function AssignChildModal({
         const fullName = `${player.firstName || ""} ${
           player.lastName || ""
         }`.toLowerCase();
-        const email = (player.email || "").toLowerCase();
-        return fullName.includes(term) || email.includes(term);
+        return fullName.includes(term);
       });
       setFilteredPlayers(filtered);
     }
@@ -186,7 +184,7 @@ export default function AssignChildModal({
                       type="text"
                       value={searchTerm}
                       onChange={(e) => setSearchTerm(e.target.value)}
-                      placeholder="Search by name or email..."
+                      placeholder="Search by name..."
                       className="input-base w-full"
                     />
                   </div>

--- a/frontend/src/components/AutoAssignmentModal.tsx
+++ b/frontend/src/components/AutoAssignmentModal.tsx
@@ -245,9 +245,11 @@ export default function AutoAssignmentModal({
                                       {player.level}
                                     </span>
                                   </div>
-                                  <p className="text-xs text-text-secondary">
-                                    {player.email}
-                                  </p>
+                                  {player.parentName && (
+                                    <p className="text-xs text-text-secondary">
+                                      Parent: {player.parentName}
+                                    </p>
+                                  )}
                                 </div>
                               </div>
                               <div className="text-right">

--- a/frontend/src/components/CreatePlayerModal.tsx
+++ b/frontend/src/components/CreatePlayerModal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Fragment, useState } from 'react';
+import { Fragment, useState, useEffect } from 'react';
 import { Dialog, Transition, Listbox } from '@headlessui/react';
 import { PlayerDTO, Level, BasicFoot } from '@/types/players';
 import { AgeGroup } from '@/types/groups';
-import { apiClient } from '@/lib/apiClient';
+import { playersAPI, usersAPI } from '@/lib/api';
 import { AssignmentService } from '@/services/assignmentService';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
@@ -16,51 +16,114 @@ interface CreatePlayerModalProps {
   onComplete: (player: PlayerDTO) => void;
 }
 
-export default function CreatePlayerModal({ 
-  isOpen, 
-  onClose, 
-  onComplete 
+export default function CreatePlayerModal({
+  isOpen,
+  onClose,
+  onComplete
 }: CreatePlayerModalProps) {
-  const [formData, setFormData] = useState<Partial<PlayerDTO>>({
+  // Player form data (no email/phone — contact info lives on parent)
+  const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
-    email: '',
-    phone: '',
-    parentName: '',
     dateOfBirth: '',
     basicFoot: BasicFoot.RIGHT,
     level: Level.DEVELOPMENT,
     isActive: true,
-    joiningDate: new Date().toISOString().split('T')[0]
+    joiningDate: new Date().toISOString().split('T')[0],
+    emergencyContactName: '',
+    emergencyContactPhone: '',
   });
-  
+
   const [birthDate, setBirthDate] = useState<Date | null>(null);
   const [joiningDate, setJoiningDate] = useState<Date | null>(new Date());
+
+  // Parent state
+  const [parentSearchQuery, setParentSearchQuery] = useState('');
+  const [parentSearchResults, setParentSearchResults] = useState<any[]>([]);
+  const [selectedParent, setSelectedParent] = useState<any | null>(null);
+  const [isCreatingNewParent, setIsCreatingNewParent] = useState(false);
+  const [newParentData, setNewParentData] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    gender: 'MALE' as string,
+  });
+  const [isSearchingParents, setIsSearchingParents] = useState(false);
 
   const [autoAssign, setAutoAssign] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Debounced parent search
+  useEffect(() => {
+    if (parentSearchQuery.length < 2 || isCreatingNewParent) {
+      setParentSearchResults([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      setIsSearchingParents(true);
+      try {
+        const results = await usersAPI.searchParents(parentSearchQuery);
+        setParentSearchResults(results);
+      } catch (err) {
+        console.error('Failed to search parents:', err);
+      } finally {
+        setIsSearchingParents(false);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [parentSearchQuery, isCreatingNewParent]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
     setError(null);
-    
-    console.log('Submitting player data:', formData);
 
     try {
-      // Create the player
-      const createdPlayer = await apiClient.post<PlayerDTO>('/players', formData);
-      console.log('Player created successfully:', createdPlayer);
-      
-      // Auto-assign if requested
+      let parentId: number;
+
+      // Step 1: Create parent if new
+      if (isCreatingNewParent) {
+        if (!newParentData.firstName || !newParentData.lastName || !newParentData.email) {
+          setError('Please fill in parent first name, last name, and email');
+          setIsSubmitting(false);
+          return;
+        }
+        const createdParent = await usersAPI.create({
+          firstName: newParentData.firstName,
+          lastName: newParentData.lastName,
+          email: newParentData.email,
+          phone: newParentData.phone,
+          gender: newParentData.gender,
+          userType: 'PARENT',
+        });
+        parentId = createdParent.id;
+      } else if (selectedParent) {
+        parentId = selectedParent.id;
+      } else {
+        setError('Please select or create a parent');
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Step 2: Create player with parentId
+      const createdPlayer = await playersAPI.create({
+        ...formData,
+        parentId,
+      });
+
+      // Step 3: Assign child to parent via join table
+      await usersAPI.assignChild(parentId, createdPlayer.id);
+
+      // Auto-assign group if requested
       if (autoAssign && formData.dateOfBirth) {
-        const group = await AssignmentService.autoAssignPlayer(createdPlayer);
-        if (group) {
-          console.log(`Player assigned to group: ${group.name}`);
-          // Update the player with the assigned group
-          createdPlayer.groupId = group.id;
-          createdPlayer.groupName = group.name;
+        try {
+          const updatedPlayer = await playersAPI.autoAssignGroup(createdPlayer.id);
+          createdPlayer.groupId = updatedPlayer.groupId;
+          createdPlayer.groupName = updatedPlayer.groupName;
+        } catch (err) {
+          console.error('Auto-assign failed:', err);
         }
       }
 
@@ -78,17 +141,21 @@ export default function CreatePlayerModal({
     setFormData({
       firstName: '',
       lastName: '',
-      email: '',
-      phone: '',
-      parentName: '',
       dateOfBirth: '',
       basicFoot: BasicFoot.RIGHT,
       level: Level.DEVELOPMENT,
       isActive: true,
-      joiningDate: new Date().toISOString().split('T')[0]
+      joiningDate: new Date().toISOString().split('T')[0],
+      emergencyContactName: '',
+      emergencyContactPhone: '',
     });
     setBirthDate(null);
     setJoiningDate(new Date());
+    setParentSearchQuery('');
+    setParentSearchResults([]);
+    setSelectedParent(null);
+    setIsCreatingNewParent(false);
+    setNewParentData({ firstName: '', lastName: '', email: '', phone: '', gender: 'MALE' });
     setAutoAssign(true);
     setError(null);
     onClose();
@@ -137,7 +204,148 @@ export default function CreatePlayerModal({
                 )}
 
                 <form onSubmit={handleSubmit} className="space-y-4">
-                  {/* Personal Information */}
+                  {/* ===== Section 1: Parent ===== */}
+                  <div className="border border-border rounded-lg p-4">
+                    <h4 className="text-sm font-medium text-text-primary mb-3">Parent / Guardian</h4>
+
+                    {!isCreatingNewParent ? (
+                      <>
+                        {/* Parent Search */}
+                        {!selectedParent ? (
+                          <div>
+                            <input
+                              type="text"
+                              value={parentSearchQuery}
+                              onChange={(e) => setParentSearchQuery(e.target.value)}
+                              placeholder="Search existing parent by name or email..."
+                              className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                            />
+                            {isSearchingParents && (
+                              <p className="text-xs text-text-secondary mt-1">Searching...</p>
+                            )}
+                            {parentSearchResults.length > 0 && (
+                              <div className="mt-2 border border-border rounded-lg max-h-40 overflow-y-auto">
+                                {parentSearchResults.map((parent) => (
+                                  <button
+                                    key={parent.id}
+                                    type="button"
+                                    onClick={() => {
+                                      setSelectedParent(parent);
+                                      setParentSearchQuery('');
+                                      setParentSearchResults([]);
+                                    }}
+                                    className="w-full p-2 text-left hover:bg-secondary border-b border-border last:border-b-0 transition-colors"
+                                  >
+                                    <p className="text-sm font-medium text-text-primary">
+                                      {parent.firstName} {parent.lastName}
+                                    </p>
+                                    <p className="text-xs text-text-secondary">{parent.email}</p>
+                                  </button>
+                                ))}
+                              </div>
+                            )}
+                            {parentSearchQuery.length >= 2 && !isSearchingParents && parentSearchResults.length === 0 && (
+                              <p className="text-xs text-text-secondary mt-1">No parents found</p>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="flex items-center justify-between bg-green-500/10 border border-green-500/20 rounded-lg p-3">
+                            <div>
+                              <p className="text-sm font-medium text-text-primary">
+                                {selectedParent.firstName} {selectedParent.lastName}
+                              </p>
+                              <p className="text-xs text-text-secondary">{selectedParent.email}</p>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => setSelectedParent(null)}
+                              className="text-xs text-accent-red hover:underline"
+                            >
+                              Change
+                            </button>
+                          </div>
+                        )}
+
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setIsCreatingNewParent(true);
+                            setSelectedParent(null);
+                            setParentSearchQuery('');
+                            setParentSearchResults([]);
+                          }}
+                          className="mt-2 text-xs text-primary hover:underline"
+                        >
+                          + Create new parent
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        {/* New Parent Form */}
+                        <div className="space-y-3">
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <label className="block text-xs font-medium text-text-secondary mb-1">First Name *</label>
+                              <input
+                                type="text"
+                                required
+                                value={newParentData.firstName}
+                                onChange={(e) => setNewParentData({...newParentData, firstName: e.target.value})}
+                                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                                placeholder="Parent first name"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs font-medium text-text-secondary mb-1">Last Name *</label>
+                              <input
+                                type="text"
+                                required
+                                value={newParentData.lastName}
+                                onChange={(e) => setNewParentData({...newParentData, lastName: e.target.value})}
+                                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                                placeholder="Parent last name"
+                              />
+                            </div>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <label className="block text-xs font-medium text-text-secondary mb-1">Email *</label>
+                              <input
+                                type="email"
+                                required
+                                value={newParentData.email}
+                                onChange={(e) => setNewParentData({...newParentData, email: e.target.value})}
+                                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                                placeholder="parent@example.com"
+                              />
+                            </div>
+                            <div>
+                              <label className="block text-xs font-medium text-text-secondary mb-1">Phone</label>
+                              <input
+                                type="tel"
+                                value={newParentData.phone}
+                                onChange={(e) => setNewParentData({...newParentData, phone: e.target.value})}
+                                className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+                                placeholder="+1234567890"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setIsCreatingNewParent(false);
+                            setNewParentData({ firstName: '', lastName: '', email: '', phone: '', gender: 'MALE' });
+                          }}
+                          className="mt-2 text-xs text-text-secondary hover:underline"
+                        >
+                          ← Search existing parent instead
+                        </button>
+                      </>
+                    )}
+                  </div>
+
+                  {/* ===== Section 2: Player Details ===== */}
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-text-secondary mb-1">
@@ -168,52 +376,7 @@ export default function CreatePlayerModal({
                     </div>
                   </div>
 
-                  {/* Contact Information */}
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-sm font-medium text-text-secondary mb-1">
-                        Email *
-                      </label>
-                      <input
-                        type="email"
-                        required
-                        value={formData.email}
-                        onChange={(e) => setFormData({...formData, email: e.target.value})}
-                        className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-                        placeholder="player@example.com"
-                      />
-                    </div>
-
-                    <div>
-                      <label className="block text-sm font-medium text-text-secondary mb-1">
-                        Phone
-                      </label>
-                      <input
-                        type="tel"
-                        value={formData.phone}
-                        onChange={(e) => setFormData({...formData, phone: e.target.value})}
-                        className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-                        placeholder="+1234567890"
-                      />
-                    </div>
-                  </div>
-
-                  {/* Parent Information */}
-                  <div>
-                    <label className="block text-sm font-medium text-text-secondary mb-1">
-                      Parent/Guardian Name *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      value={formData.parentName}
-                      onChange={(e) => setFormData({...formData, parentName: e.target.value})}
-                      className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-                      placeholder="Enter parent/guardian name"
-                    />
-                  </div>
-
-                  {/* Player Details */}
+                  {/* Date fields */}
                   <div className="grid grid-cols-2 gap-4">
                     <div>
                       <label className="block text-sm font-medium text-text-secondary mb-1">
@@ -279,8 +442,8 @@ export default function CreatePlayerModal({
                       <label className="block text-sm font-medium text-text-secondary mb-1">
                         Preferred Foot
                       </label>
-                      <Listbox 
-                        value={formData.basicFoot} 
+                      <Listbox
+                        value={formData.basicFoot}
                         onChange={(value) => setFormData({...formData, basicFoot: value})}
                       >
                         <div className="relative">
@@ -322,8 +485,8 @@ export default function CreatePlayerModal({
                       <label className="block text-sm font-medium text-text-secondary mb-1">
                         Level
                       </label>
-                      <Listbox 
-                        value={formData.level} 
+                      <Listbox
+                        value={formData.level}
                         onChange={(value) => setFormData({...formData, level: value})}
                       >
                         <div className="relative">
@@ -362,7 +525,35 @@ export default function CreatePlayerModal({
                     </div>
                   </div>
 
-                  {/* Auto-assign Option */}
+                  {/* Emergency Contact */}
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-text-secondary mb-1">
+                        Emergency Contact Name
+                      </label>
+                      <input
+                        type="text"
+                        value={formData.emergencyContactName}
+                        onChange={(e) => setFormData({...formData, emergencyContactName: e.target.value})}
+                        className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                        placeholder="Emergency contact name"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-text-secondary mb-1">
+                        Emergency Contact Phone
+                      </label>
+                      <input
+                        type="tel"
+                        value={formData.emergencyContactPhone}
+                        onChange={(e) => setFormData({...formData, emergencyContactPhone: e.target.value})}
+                        className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                        placeholder="+1234567890"
+                      />
+                    </div>
+                  </div>
+
+                  {/* ===== Section 3: Auto-assign ===== */}
                   <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4">
                     <label className="flex items-center space-x-3">
                       <input

--- a/frontend/src/components/EditPlayerModal.tsx
+++ b/frontend/src/components/EditPlayerModal.tsx
@@ -25,12 +25,9 @@ export default function EditPlayerModal({
   const [formData, setFormData] = useState<Partial<PlayerDTO>>({
     firstName: '',
     lastName: '',
-    email: '',
-    phone: '',
-    parentName: '',
     dateOfBirth: '',
-    joiningDate: '', // Add joiningDate field
-    groupId: undefined, // Add groupId field to preserve group assignment
+    joiningDate: '',
+    groupId: undefined,
     basicFoot: BasicFoot.RIGHT,
     level: Level.DEVELOPMENT,
     isActive: true
@@ -57,16 +54,12 @@ export default function EditPlayerModal({
       setFormData({
         firstName: player.firstName || '',
         lastName: player.lastName || '',
-        email: player.email || '',
-        phone: player.phone || '',
-        parentName: player.parentName || '',
         dateOfBirth: player.dateOfBirth || '',
-        joiningDate: player.joiningDate || '', // Preserve existing joining date
-        groupId: player.groupId, // Preserve existing group assignment
+        joiningDate: player.joiningDate || '',
+        groupId: player.groupId,
         basicFoot: player.basicFoot || BasicFoot.RIGHT,
         level: player.level || Level.DEVELOPMENT,
         isActive: player.isActive,
-        // Preserve additional fields that might not be in the edit form
         gender: player.gender,
         address: player.address,
         emergencyContactName: player.emergencyContactName,
@@ -115,12 +108,9 @@ export default function EditPlayerModal({
     setFormData({
       firstName: '',
       lastName: '',
-      email: '',
-      phone: '',
-      parentName: '',
       dateOfBirth: '',
-      joiningDate: '', // Reset joiningDate as well
-      groupId: undefined, // Reset groupId as well
+      joiningDate: '',
+      groupId: undefined,
       basicFoot: BasicFoot.RIGHT,
       level: Level.DEVELOPMENT,
       isActive: true
@@ -242,51 +232,6 @@ export default function EditPlayerModal({
                         placeholder="Enter last name"
                       />
                     </div>
-                  </div>
-
-                  {/* Contact Information */}
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <label className="text-caption mb-1">
-                        Email *
-                      </label>
-                      <input
-                        type="email"
-                        required
-                        value={formData.email}
-                        onChange={(e) => setFormData({...formData, email: e.target.value})}
-                        className="input-base"
-                        placeholder="player@example.com"
-                      />
-                    </div>
-
-                    <div>
-                      <label className="text-caption mb-1">
-                        Phone
-                      </label>
-                      <input
-                        type="tel"
-                        value={formData.phone}
-                        onChange={(e) => setFormData({...formData, phone: e.target.value})}
-                        className="input-base"
-                        placeholder="+1234567890"
-                      />
-                    </div>
-                  </div>
-
-                  {/* Parent Information */}
-                  <div>
-                    <label className="block text-sm font-medium text-text-secondary mb-1">
-                      Parent/Guardian Name *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      value={formData.parentName}
-                      onChange={(e) => setFormData({...formData, parentName: e.target.value})}
-                      className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
-                      placeholder="Enter parent/guardian name"
-                    />
                   </div>
 
                   {/* Player Details */}

--- a/frontend/src/components/PlayerCard.tsx
+++ b/frontend/src/components/PlayerCard.tsx
@@ -129,26 +129,6 @@ export default function PlayerCard({
           </div>
         </div>
 
-        {/* Contact Info */}
-        <div className="space-y-2 mb-4">
-          <div className="flex items-center text-primary">
-            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-              <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-              <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-            </svg>
-            <span className="text-sm">{player.email}</span>
-          </div>
-
-          {player.phone && (
-            <div className="flex items-center text-primary">
-              <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
-              </svg>
-              <span className="text-sm">{player.phone}</span>
-            </div>
-          )}
-        </div>
-
         {/* Age & Date of Birth */}
         {player.dateOfBirth && (
           <div className="mb-4">

--- a/frontend/src/components/PromotionModal.tsx
+++ b/frontend/src/components/PromotionModal.tsx
@@ -147,10 +147,6 @@ export default function PromotionModal({
                         </span>
                       </div>
                       <div className="space-y-2 text-sm">
-                        <div className="flex justify-between">
-                          <span className="text-text-secondary">Email:</span>
-                          <span className="text-text-secondary">{player.email}</span>
-                        </div>
                         {player.dateOfBirth && (
                           <div className="flex justify-between">
                             <span className="text-text-secondary">Age:</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -332,6 +332,11 @@ export const usersAPI = {
     return apiRequest<UserResponse>("/users/me");
   },
 
+  // Parent search
+  searchParents: async (search: string): Promise<UserResponse[]> => {
+    return apiRequest<UserResponse[]>(`/users/parents/search?search=${encodeURIComponent(search)}`);
+  },
+
   // Parent-child management endpoints
   assignChild: async (
     parentId: number,

--- a/frontend/src/types/players.ts
+++ b/frontend/src/types/players.ts
@@ -18,12 +18,11 @@ export interface PlayerDTO {
   id?: number;
   firstName: string;
   lastName: string;
-  email: string;
-  phone?: string;
   dateOfBirth?: string; // ISO date string
   gender?: Gender;
   address?: string;
-  parentName: string;
+  parentId?: number;
+  parentName?: string;
   joiningDate?: string; // ISO date string
   level: Level;
   basicFoot?: BasicFoot;
@@ -33,7 +32,7 @@ export interface PlayerDTO {
   inactiveReason?: string;
   createdAt?: string; // ISO datetime string
   updatedAt?: string; // ISO datetime string
-  
+
   // Group information
   groupId?: number;
   groupName?: string;


### PR DESCRIPTION
## Summary
- Remove `email` and `phone` from Player entity — contact info now lives exclusively on the parent User
- Add `GET /users/parents/search` endpoint for parent lookup by name/email
- Redesign `CreatePlayerModal` with parent search/select + inline parent creation
- Single submission flow: create parent (if new) → create player with parentId → link via `player_parents` join table
- Update all player-related components (EditPlayerModal, PlayerCard, AssignChildModal, PromotionModal, AutoAssignmentModal) to remove email/phone references

## Changes

### Backend
- **V44 migration**: Drop `email`/`phone` columns from `players` table
- **Player entity/DTO**: Remove email/phone fields and annotations
- **PlayerService**: Remove email uniqueness checks, fix parent linking to use `addParent()` instead of deprecated `setParent()`
- **PlayerRepository**: Remove `existsByEmail`, `findByEmailWithGroup`, email from search JPQL
- **UserRepository/Service/Controller**: Add parent search endpoint

### Frontend
- **CreatePlayerModal**: Complete redesign with debounced parent search (300ms), selectable results, "Create new parent" inline form
- **EditPlayerModal**: Remove email/phone form fields
- **PlayerCard**: Remove contact info section
- **Other modals**: Remove email references, show parentName instead

## Test plan
- [ ] Backend compiles: `cd backend && ./mvnw compile -q`
- [ ] Frontend builds: `cd frontend && npm run build`
- [ ] Flyway V44 migration runs successfully on startup
- [ ] Create player via new modal: search existing parent → select → fill player details → submit
- [ ] Create player with new parent: toggle "Create new parent" → fill parent + player → submit
- [ ] Verify player list no longer shows email column
- [ ] Verify player cards show parent name instead of email/phone

> **Note:** This branch is based on `master`. May need rebasing onto `develop` if there are conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)