### PR TITLE
Fix JWT signing secret never being read from the environment

### DIFF
--- a/backend/src/main/java/com/batal/security/JwtUtil.java
+++ b/backend/src/main/java/com/batal/security/JwtUtil.java
@@ -2,26 +2,60 @@ package com.batal.security;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
-    
+
+    /** HS256 requires a key of at least 256 bits. */
+    private static final int MIN_SECRET_BYTES = 32;
+
+    /** Previously hardcoded in application.properties, so it is public in this repository's history. */
+    private static final String COMPROMISED_SECRET =
+            "batal-secret-key-change-in-production-make-it-very-long-and-secure";
+
     @Value("${batal.jwt.secret}")
     private String jwtSecret;
-    
+
     @Value("${batal.jwt.expiration}")
     private long jwtExpirationMs;
-    
+
+    private SecretKey signingKey;
+
+    /**
+     * Validates the configured secret at startup so a misconfiguration fails loudly here
+     * rather than silently signing tokens with a guessable key.
+     */
+    @PostConstruct
+    void initSigningKey() {
+        if (jwtSecret == null || jwtSecret.isBlank()) {
+            throw new IllegalStateException(
+                    "BATAL_JWT_SECRET is not set. Generate one with `openssl rand -base64 48` "
+                            + "and provide it via the environment before starting the application.");
+        }
+        if (COMPROMISED_SECRET.equals(jwtSecret)) {
+            throw new IllegalStateException(
+                    "BATAL_JWT_SECRET is set to the value that was committed to this repository and is "
+                            + "therefore public. Generate a replacement with `openssl rand -base64 48`.");
+        }
+        byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        if (keyBytes.length < MIN_SECRET_BYTES) {
+            throw new IllegalStateException("BATAL_JWT_SECRET must be at least " + MIN_SECRET_BYTES
+                    + " bytes to sign with HS256, but the configured value is " + keyBytes.length + " bytes.");
+        }
+        this.signingKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
     private SecretKey getSigningKey() {
-        byte[] keyBytes = jwtSecret.getBytes();
-        return Keys.hmacShaKeyFor(keyBytes);
+        return signingKey;
     }
     
     public String generateJwtToken(Authentication authentication) {
@@ -71,12 +105,17 @@ public class JwtUtil {
                 .build()
                 .parseClaimsJws(authToken);
             return true;
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            // Expected for tokens issued under a previous signing secret.
+            System.err.println("JWT signature does not match: " + e.getMessage());
         } catch (MalformedJwtException e) {
             System.err.println("Invalid JWT token: " + e.getMessage());
         } catch (ExpiredJwtException e) {
             System.err.println("JWT token is expired: " + e.getMessage());
         } catch (UnsupportedJwtException e) {
             System.err.println("JWT token is unsupported: " + e.getMessage());
+        } catch (JwtException e) {
+            System.err.println("JWT token could not be validated: " + e.getMessage());
         } catch (IllegalArgumentException e) {
             System.err.println("JWT claims string is empty: " + e.getMessage());
         }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -20,7 +20,10 @@ server.port=8080
 server.servlet.context-path=/api
 
 # JWT Configuration
-batal.jwt.secret=batal-secret-key-change-in-production-make-it-very-long-and-secure
+# The signing secret deliberately has no fallback value: the application refuses to
+# start unless BATAL_JWT_SECRET is set, so a shared or publicly known key can never
+# be used by accident. Generate one with: openssl rand -base64 48
+batal.jwt.secret=${BATAL_JWT_SECRET:}
 batal.jwt.expiration=28800000
 
 # CORS Configuration

--- a/backend/src/test/java/com/batal/BatalApplicationTests.java
+++ b/backend/src/test/java/com/batal/BatalApplicationTests.java
@@ -3,7 +3,7 @@ package com.batal;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "batal.jwt.secret=test-only-jwt-secret-not-used-outside-of-tests")
 class BatalApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/batal/security/JwtUtilTest.java
+++ b/backend/src/test/java/com/batal/security/JwtUtilTest.java
@@ -1,0 +1,69 @@
+package com.batal.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JwtUtilTest {
+
+    private static final String VALID_SECRET = "a-test-secret-that-is-long-enough-for-hs256-signing";
+
+    private JwtUtil jwtUtilWithSecret(String secret) {
+        JwtUtil jwtUtil = new JwtUtil();
+        ReflectionTestUtils.setField(jwtUtil, "jwtSecret", secret);
+        ReflectionTestUtils.setField(jwtUtil, "jwtExpirationMs", 28800000L);
+        return jwtUtil;
+    }
+
+    @Test
+    void refusesToStartWhenSecretIsMissing() {
+        JwtUtil jwtUtil = jwtUtilWithSecret("");
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, jwtUtil::initSigningKey);
+        assertTrue(thrown.getMessage().contains("BATAL_JWT_SECRET is not set"));
+    }
+
+    @Test
+    void refusesToStartWhenSecretIsTheOneCommittedToTheRepository() {
+        JwtUtil jwtUtil = jwtUtilWithSecret("batal-secret-key-change-in-production-make-it-very-long-and-secure");
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, jwtUtil::initSigningKey);
+        assertTrue(thrown.getMessage().contains("public"));
+    }
+
+    @Test
+    void refusesToStartWhenSecretIsTooShortForHs256() {
+        JwtUtil jwtUtil = jwtUtilWithSecret("too-short-for-hs256");
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class, jwtUtil::initSigningKey);
+        assertTrue(thrown.getMessage().contains("at least 32 bytes"));
+    }
+
+    @Test
+    void signsAndReadsBackATokenWithAValidSecret() {
+        JwtUtil jwtUtil = jwtUtilWithSecret(VALID_SECRET);
+        jwtUtil.initSigningKey();
+
+        String token = jwtUtil.generateJwtToken("coach@batal-academy.com");
+
+        assertNotNull(token);
+        assertTrue(jwtUtil.validateJwtToken(token));
+        assertEquals("coach@batal-academy.com", jwtUtil.getUsernameFromJwtToken(token));
+    }
+
+    @Test
+    void rejectsATokenSignedWithADifferentSecret() {
+        JwtUtil issuer = jwtUtilWithSecret(VALID_SECRET);
+        issuer.initSigningKey();
+        JwtUtil verifier = jwtUtilWithSecret("a-completely-different-secret-of-sufficient-length");
+        verifier.initSigningKey();
+
+        String token = issuer.generateJwtToken("coach@batal-academy.com");
+
+        assertTrue(!verifier.validateJwtToken(token));
+    }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,6 +43,8 @@ services:
       SPRING_DATASOURCE_PASSWORD: batal_password
       MINIO_ENDPOINT: http://minio:9000
       SPRING_PROFILES_ACTIVE: dev
+      # Local development only. Never reuse this value for a deployed environment.
+      BATAL_JWT_SECRET: ${JWT_SECRET:-local-development-only-jwt-secret-do-not-deploy}
     ports:
       - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       MINIO_ENDPOINT: http://minio:9000
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      JWT_SECRET: ${JWT_SECRET:-default-jwt-secret-change-in-production}
+      BATAL_JWT_SECRET: "${JWT_SECRET:?JWT_SECRET must be set in .env - generate one with `openssl rand -base64 48`}"
     depends_on:
       - postgres
       - minio


### PR DESCRIPTION
## Problem

The deploy pipeline writes `JWT_SECRET` into the backend container, but Spring binds `batal.jwt.secret` from **`BATAL_JWT_SECRET`**. The names never matched, so the override was silently discarded and every token has been signed with the literal hardcoded in `application.properties` — a value that is public in this repository's history.

The `JWT_SECRET` Actions secret has existed since 2025-09-01 and has never had any effect.

## Changes

- **`docker-compose.yml`** — pass the secret as `BATAL_JWT_SECRET`, still reading the existing `JWT_SECRET` `.env` key so the deploy workflow needs no change. The `:?` guard aborts the deploy instead of falling back to `default-jwt-secret-change-in-production`.
- **`application.properties`** — hardcoded secret removed; the property now has no usable fallback.
- **`JwtUtil`** — validate at startup and refuse to boot on a blank secret, the previously committed one, or anything under the 32 bytes HS256 requires. Key is built once and derived as UTF-8 rather than the platform default charset.
- **`JwtUtil.validateJwtToken`** — catch `SignatureException`, which previously propagated instead of returning `false`. `JwtRequestFilter`'s blanket `catch (Exception e)` meant callers still got a clean 401, but this is the path every existing token takes the moment the secret rotates.
- **`docker-compose.dev.yml`** — local-only default, since the backend now refuses to start without a secret.
- **`JwtUtilTest`** — new: rejected-secret cases, sign/verify round trip, cross-secret rejection.

## Verification

- `JwtUtilTest` — 5/5 pass
- Backend compiles clean
- `docker compose config` without `JWT_SECRET` → exit 1 with guidance; with it → binds `BATAL_JWT_SECRET`
- Checked through the real `-f docker-compose.yml -f docker-compose.deploy.yml` production merge

## Deploy notes

The `JWT_SECRET` Actions secret was rotated to a fresh `openssl rand -base64 48` value on 2026-08-06 before this PR. Merging makes it take effect for the first time.

**Tokens signed with the old key become invalid**, so active sessions will need to log in once after deployment. The frontend already redirects to `/login` on 401, so this degrades cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)