### PR TITLE
Redirect to login instead of rendering a blank page on a rejected token

### DIFF
--- a/frontend/src/app/parent/layout.tsx
+++ b/frontend/src/app/parent/layout.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { logout } from "@/store/authSlice";
-import { RoleGuard } from "@/components/RoleGuard";
+import ProtectedRoute from "@/components/ProtectedRoute";
 import { UserRole } from "@/types/auth";
 import ChildSelector from "@/components/parent/ChildSelector";
 import { ResponsiveLayout } from "@/components/responsive";
@@ -145,7 +145,7 @@ export default function ParentLayout({ children }: ParentLayoutProps) {
   );
 
   return (
-    <RoleGuard allowedRoles={[UserRole.PARENT]}>
+    <ProtectedRoute allowedRoles={[UserRole.PARENT]}>
       <ResponsiveLayout
         sidebar={sidebarContent}
         navItems={navItemsForMobile}
@@ -160,6 +160,6 @@ export default function ParentLayout({ children }: ParentLayoutProps) {
       >
         <div className="max-w-6xl mx-auto">{children}</div>
       </ResponsiveLayout>
-    </RoleGuard>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/app/player/layout.tsx
+++ b/frontend/src/app/player/layout.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { logout } from "@/store/authSlice";
-import { RoleGuard } from "@/components/RoleGuard";
+import ProtectedRoute from "@/components/ProtectedRoute";
 import { UserRole } from "@/types/auth";
 import { ResponsiveLayout } from "@/components/responsive";
 import {
@@ -139,7 +139,7 @@ export default function PlayerLayout({ children }: PlayerLayoutProps) {
   );
 
   return (
-    <RoleGuard allowedRoles={[UserRole.PARENT]}>
+    <ProtectedRoute allowedRoles={[UserRole.PARENT]}>
       <ResponsiveLayout
         sidebar={sidebarContent}
         navItems={navItemsForMobile}
@@ -153,6 +153,6 @@ export default function PlayerLayout({ children }: PlayerLayoutProps) {
       >
         <div className="max-w-6xl mx-auto">{children}</div>
       </ResponsiveLayout>
-    </RoleGuard>
+    </ProtectedRoute>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -131,6 +131,19 @@ async function apiRequest<T>(
     const response = await fetch(url, config);
 
     if (!response.ok) {
+      // A stored token the backend rejects is unusable: drop it and send the
+      // user to log in, rather than leaving the app authenticated-looking with
+      // no user behind it. Auth endpoints are exempt because a failed login
+      // legitimately answers 401 and needs to surface its error to the form.
+      if (
+        response.status === 401 &&
+        !endpoint.startsWith("/auth/") &&
+        typeof window !== "undefined"
+      ) {
+        tokenManager.removeToken();
+        window.location.href = "/login";
+      }
+
       const errorData = await response.json().catch(() => ({}));
 
       // Handle structured error response from backend (ErrorResponse class)


### PR DESCRIPTION
## Problem

Reported in production: refreshing `/player/dashboard` rendered a completely blank page — no error, no redirect, no way out.

The parent and player layouts guarded with `RoleGuard`, whose `fallback` **defaults to `null`** and which never redirects. When a stored token is rejected by the backend, `initializeAuth` clears the user from state and those layouts render nothing at all.

`initializeAuth` only decodes the JWT locally (`authSlice.ts:144`), so a token with a future `exp` looks usable right up until `/users/me` answers 401. That fires on **any** auth failure — including ordinary 8-hour token expiry — so a parent refreshing the morning after logging in would get a blank screen. The JWT secret rotation in #45 simply made it happen to everyone at once.

`/admin`, `/manager` and `/coach` were unaffected: they already use `ProtectedRoute`, which redirects properly.

## Changes

- `app/player/layout.tsx`, `app/parent/layout.tsx` — guard with `ProtectedRoute` instead of `RoleGuard`. It shows a spinner while auth resolves and routes unauthenticated users to `/login`.
- `lib/api.ts` — `apiRequest` clears the stored token and redirects on 401, matching what `apiClient` already does. **`/auth/*` is exempt**, because a failed login legitimately answers 401 and its error belongs on the form.

## Verification

Headless browser against a local stack, seeding a structurally valid but wrongly-signed token into `localStorage` — the exact reported scenario. Same test run against both versions:

| | Before | After |
|---|---|---|
| Final URL | `/player/dashboard` | **`/login`** |
| Visible text | **0 chars — blank** | 213 chars, login form |
| Stale token | retained | **cleared** |

Regressions specifically checked:

- **Failed login** — stays on `/login`, shows "Sign In Failed", `401 /api/auth/login` handled without wiping the page
- **Real parent login** — reaches `/parent/dashboard`, renders correctly, **and survives a reload** (the action that triggered the report)

## Deploy note

Users still holding a pre-rotation token see the blank page until this ships. `localStorage.clear()` is the per-user workaround in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)