### PR TITLE
Give production its own profile and stop publishing services publicly

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,0 +1,19 @@
+# Production overrides, layered on top of application.properties.
+# Activated by SPRING_PROFILES_ACTIVE=prod (see docker-compose.deploy.yml).
+#
+# application.properties holds developer-oriented defaults. Anything that should
+# not be true of a deployed environment belongs here.
+
+# Logging: no SQL echo, and no request-level Spring Security internals.
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+logging.level.com.batal=INFO
+logging.level.org.springframework.security=WARN
+
+# Fail loudly when the Flyway history table is missing rather than assuming the
+# schema is already current and silently skipping ahead of it.
+spring.flyway.baseline-on-migrate=false
+
+# Only the public site may call the API; local development origins are
+# deliberately absent here.
+batal.cors.allowed-origins=https://batal-academy.com,https://www.batal-academy.com

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -37,9 +37,6 @@ spring.servlet.multipart.max-request-size=10MB
 logging.level.com.batal=DEBUG
 logging.level.org.springframework.security=DEBUG
 
-#Local environment development
-batal.player-default-password=player123
-
 # Email Configuration (Titan Email - Correct SMTP Settings)
 # Titan Email SMTP Configuration - SSL port 465
 spring.mail.host=SMTP.titan.email

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -5,8 +5,6 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - batal-network
-    ports:
-      - "5432:5432"
 
   minio:
     container_name: batal-minio
@@ -14,20 +12,15 @@ services:
       - minio_data:/data
     networks:
       - batal-network
-    ports:
-      - "9000:9000"
-      - "9001:9001"
 
   backend:
     image: ${BACKEND_IMAGE:-ghcr.io/nabiljarrai/batal-backend:master}
     container_name: batal-backend
     environment:
-      SPRING_PROFILES_ACTIVE: dev
+      SPRING_PROFILES_ACTIVE: prod
       MAIL_USERNAME: ${MAIL_USERNAME}
       MAIL_PASSWORD: ${MAIL_PASSWORD}
       FRONTEND_URL: https://${DOMAIN:-batal-academy.com}
-    ports:
-      - "8080:8080"
     networks:
       - batal-network
 
@@ -36,8 +29,6 @@ services:
     container_name: batal-frontend
     environment:
       NEXT_PUBLIC_API_URL: https://${DOMAIN:-batal-academy.com}/api
-    ports:
-      - "3000:3000"
     networks:
       - batal-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: postgres:15-alpine
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_DB: batal_db
       POSTGRES_USER: batal_user
@@ -18,8 +18,8 @@ services:
   minio:
     image: minio/minio:latest
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
@@ -36,7 +36,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/batal_db
       SPRING_DATASOURCE_USERNAME: batal_user
@@ -58,7 +58,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       NODE_ENV: production
       NEXT_PUBLIC_API_URL: http://backend:8080/api

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -16,21 +16,13 @@ class ApiClient {
     };
 
     const url = `${API_URL}${endpoint}`;
-    console.log('API Request:', options.method || 'GET', url);
-    console.log('Headers:', headers);
-    if (options.body) {
-      console.log('Body:', options.body);
-    }
 
     const response = await fetch(url, {
       ...options,
       headers,
     });
 
-    console.log('Response status:', response.status);
-
     if (response.status === 401) {
-      console.log('Unauthorized - redirecting to login');
       AuthService.clearTokens();
       if (typeof window !== 'undefined') {
         window.location.href = '/login';


### PR DESCRIPTION
## Problem

`application.properties` holds developer-oriented defaults and was the **only** configuration the deployed environment had.

`SPRING_PROFILES_ACTIVE` was set to `dev` with no `application-dev.properties` and no `@Profile` beans to match, so the setting did nothing — while leaving an obvious trap: the moment anyone adds that file, production silently inherits it.

Live on production as a result: SQL echo, DEBUG-level Spring Security logging, `localhost:3000` accepted as a CORS origin, Flyway configured to baseline rather than fail on a missing schema history, and Postgres + MinIO published to the public internet.

## Changes

- **`application-prod.properties`** (new) — SQL echo off, `com.batal` → INFO, Spring Security → WARN, `baseline-on-migrate=false` so a missing schema history fails loudly instead of skipping ahead, CORS narrowed to the public site.
- **`docker-compose.deploy.yml`** — `SPRING_PROFILES_ACTIVE: dev` → `prod`.
- **`docker-compose.yml`** — published ports bound to `127.0.0.1`. nginx already proxies to `127.0.0.1`, and the backend reaches Postgres over the internal Docker network rather than the published port, so neither is affected.
- **Dropped the duplicate `ports` list from the deploy overlay.** Compose *appends* sequences, so declaring them in both files bound every port twice — that would have failed allocation and broken the deploy. Caught by inspecting the merged `docker compose config` rather than trusting the edit.
- **`apiClient.ts`** — stop logging request headers, bodies and the bearer token to the browser console.
- Removed `batal.player-default-password`, which nothing reads.

## Verification

Booted the backend under the prod profile against a local Postgres:

- starts clean
- **0** Hibernate SQL echo lines
- **0** DEBUG lines from `com.batal` or Spring Security
- Flyway validated 42 migrations against an existing history with `baseline-on-migrate=false`
- CORS: `localhost:3000` → **403**, `https://batal-academy.com` → **200**

Merged `docker compose config` re-checked after rebasing onto master: exactly one binding per port, all on `127.0.0.1`. Frontend typechecks clean.

CORS narrowing is safe for the app itself: nginx serves the site and the API on the same origin (`batal-academy.com` and `batal-academy.com/api`), so browser requests never trigger a cross-origin check.

## Operator note

Postgres (`5432`) and MinIO (`9000`) are no longer reachable from the internet. Connecting with a DB client from a laptop now needs a tunnel:

```
ssh -L 5432:127.0.0.1:5432 user@vps
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)