### PR TITLE
Let an admin set a password directly on any user account

### DIFF
--- a/backend/src/main/java/com/batal/controller/UserController.java
+++ b/backend/src/main/java/com/batal/controller/UserController.java
@@ -6,6 +6,7 @@ import com.batal.dto.UserUpdateRequest;
 import com.batal.dto.UserStatusUpdateRequest;
 import com.batal.dto.ChildSummaryDTO;
 import com.batal.dto.AssignChildRequest;
+import com.batal.dto.AdminPasswordResetRequest;
 import com.batal.entity.User;
 import com.batal.repository.UserRepository;
 import com.batal.service.UserService;
@@ -149,6 +150,16 @@ public class UserController {
             @RequestParam(required = false) String query) {
         List<UserResponse> parents = userService.searchParentUsers(query);
         return ResponseEntity.ok(parents);
+    }
+
+    // POST /api/users/{id}/reset-password - Admin sets a user's password directly
+    @PostMapping("/{id}/reset-password")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<UserResponse> resetUserPassword(
+            @PathVariable Long id,
+            @Valid @RequestBody AdminPasswordResetRequest request) {
+        UserResponse updatedUser = userService.resetUserPassword(id, request);
+        return ResponseEntity.ok(updatedUser);
     }
 
     // ========== PARENT-CHILD MANAGEMENT ENDPOINTS ==========

--- a/backend/src/main/java/com/batal/dto/AdminPasswordResetRequest.java
+++ b/backend/src/main/java/com/batal/dto/AdminPasswordResetRequest.java
@@ -1,0 +1,32 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO for an administrator setting a password directly on another user's account.
+ * Unlike {@link ResetPasswordRequest} there is no token: authorisation comes from
+ * the caller's ADMIN role rather than from something emailed to the account owner.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminPasswordResetRequest {
+
+    @NotBlank(message = "Password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String password;
+
+    @NotBlank(message = "Password confirmation is required")
+    private String confirmPassword;
+
+    /**
+     * Check if password and confirmation match
+     */
+    public boolean isPasswordMatching() {
+        return password != null && password.equals(confirmPassword);
+    }
+}

--- a/backend/src/main/java/com/batal/service/UserService.java
+++ b/backend/src/main/java/com/batal/service/UserService.java
@@ -4,6 +4,7 @@ import com.batal.dto.UserCreateRequest;
 import com.batal.dto.UserResponse;
 import com.batal.dto.UserUpdateRequest;
 import com.batal.dto.UserStatusUpdateRequest;
+import com.batal.dto.AdminPasswordResetRequest;
 import com.batal.dto.ChildSummaryDTO;
 import com.batal.entity.User;
 import com.batal.entity.Role;
@@ -13,9 +14,11 @@ import com.batal.exception.ResourceAlreadyExistsException;
 import com.batal.exception.ResourceNotFoundException;
 import com.batal.exception.SelfDeletionException;
 import com.batal.exception.BusinessRuleException;
+import com.batal.exception.ValidationException;
 import com.batal.repository.UserRepository;
 import com.batal.repository.RoleRepository;
 import com.batal.repository.PlayerRepository;
+import com.batal.repository.PasswordSetupTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,6 +47,9 @@ public class UserService {
 
     @Autowired
     private PlayerRepository playerRepository;
+
+    @Autowired
+    private PasswordSetupTokenRepository passwordSetupTokenRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -291,6 +297,35 @@ public class UserService {
         user.setUpdatedAt(LocalDateTime.now());
         
         User savedUser = userRepository.save(user);
+        List<String> roles = savedUser.getRoles().stream()
+                .map(role -> role.getName())
+                .collect(Collectors.toList());
+        return new UserResponse(savedUser, roles);
+    }
+
+    /**
+     * Set a user's password directly, on behalf of an administrator.
+     *
+     * Any outstanding setup or reset tokens for the account are invalidated, so a
+     * link mailed out earlier cannot be used to override what the admin just set.
+     * Note that JWTs already issued to this user stay valid until they expire:
+     * tokens are stateless and are not tracked server-side.
+     */
+    public UserResponse resetUserPassword(Long id, AdminPasswordResetRequest request) {
+        if (!request.isPasswordMatching()) {
+            throw new ValidationException("confirmPassword", "Password and confirmation do not match");
+        }
+
+        User user = userRepository.findByIdWithRoles(id)
+                .orElseThrow(() -> new ResourceNotFoundException("User", id));
+
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setPasswordSetAt(LocalDateTime.now());
+        user.setUpdatedAt(LocalDateTime.now());
+
+        User savedUser = userRepository.save(user);
+        passwordSetupTokenRepository.invalidateAllUserTokens(savedUser.getId(), LocalDateTime.now());
+
         List<String> roles = savedUser.getRoles().stream()
                 .map(role -> role.getName())
                 .collect(Collectors.toList());

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ import EditUserModal from '@/components/EditUserModal';
 import EditPlayerModal from '@/components/EditPlayerModal';
 import EditGroupModal from '@/components/EditGroupModal';
 import DeleteConfirmationModal from '@/components/DeleteConfirmationModal';
+import ResetPasswordModal from '@/components/ResetPasswordModal';
 import ReassignPlayerModal from '@/components/ReassignPlayerModal';
 import AssignChildModal from '@/components/AssignChildModal';
 import SkillsManagement from '@/components/skills/SkillsManagement';
@@ -108,6 +109,7 @@ export default function AdminDashboard() {
 
   // Edit modals
   const [editUserModal, setEditUserModal] = useState<{ isOpen: boolean; userId: number | null }>({ isOpen: false, userId: null });
+  const [resetPasswordModal, setResetPasswordModal] = useState<{ isOpen: boolean; userId: number | null }>({ isOpen: false, userId: null });
   const [editPlayerModal, setEditPlayerModal] = useState<{ isOpen: boolean; playerId: number | null }>({ isOpen: false, playerId: null });
   const [editGroupModal, setEditGroupModal] = useState<{ isOpen: boolean; groupId: number | null }>({ isOpen: false, groupId: null });
 
@@ -1000,6 +1002,7 @@ export default function AdminDashboard() {
                       onAssignChild={handleAssignChild}
                       onUnassignChild={handleUnassignChild}
                       onResendSetupEmail={handleResendSetupEmail}
+                      onResetPassword={(userId) => setResetPasswordModal({ isOpen: true, userId })}
                       showActions={true}
                       assignedGroupsCount={coachInfo.assignedGroupsCount}
                       assignedGroupNames={coachInfo.assignedGroupNames}
@@ -1229,6 +1232,17 @@ export default function AdminDashboard() {
             setEditUserModal({ isOpen: false, userId: null });
             showSuccess('User updated successfully');
           }}
+        />
+
+        <ResetPasswordModal
+          isOpen={resetPasswordModal.isOpen}
+          userId={resetPasswordModal.userId}
+          userName={users.find(u => u.id === resetPasswordModal.userId)?.firstName
+            ? `${users.find(u => u.id === resetPasswordModal.userId)?.firstName} ${users.find(u => u.id === resetPasswordModal.userId)?.lastName ?? ''}`.trim()
+            : undefined}
+          userEmail={users.find(u => u.id === resetPasswordModal.userId)?.email}
+          onClose={() => setResetPasswordModal({ isOpen: false, userId: null })}
+          onSuccess={() => showSuccess('Password updated successfully')}
         />
 
         <EditPlayerModal

--- a/frontend/src/components/ResetPasswordModal.tsx
+++ b/frontend/src/components/ResetPasswordModal.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { Fragment, useEffect, useState } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { usersAPI } from '@/lib/api';
+
+interface ResetPasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userId: number | null;
+  userName?: string;
+  userEmail?: string;
+  onSuccess?: () => void;
+}
+
+const MIN_LENGTH = 8;
+
+export default function ResetPasswordModal({
+  isOpen,
+  onClose,
+  userId,
+  userName,
+  userEmail,
+  onSuccess,
+}: ResetPasswordModalProps) {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  // Never carry one user's typed password over to the next user's dialog.
+  useEffect(() => {
+    if (isOpen) {
+      setPassword('');
+      setConfirmPassword('');
+      setShowPassword(false);
+      setError(null);
+      setDone(false);
+    }
+  }, [isOpen, userId]);
+
+  const tooShort = password.length > 0 && password.length < MIN_LENGTH;
+  const mismatch = confirmPassword.length > 0 && password !== confirmPassword;
+  const canSubmit =
+    !isLoading && password.length >= MIN_LENGTH && password === confirmPassword;
+
+  const handleSubmit = async () => {
+    if (!userId || !canSubmit) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      await usersAPI.resetPassword(userId, password, confirmPassword);
+      setDone(true);
+      onSuccess?.();
+    } catch (err: any) {
+      setError(err?.message || 'Could not reset the password. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={isLoading ? () => {} : onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                {done ? (
+                  <>
+                    <Dialog.Title className="text-lg font-semibold text-gray-900">
+                      Password updated
+                    </Dialog.Title>
+                    <p className="mt-2 text-sm text-gray-600">
+                      {userName || 'This user'} can now sign in with the new password.
+                      Share it with them directly — it is not sent by email.
+                    </p>
+                    <p className="mt-3 rounded-lg bg-amber-50 p-3 text-xs text-amber-800">
+                      If they are currently signed in elsewhere, that session stays
+                      active until their token expires.
+                    </p>
+                    <div className="mt-6 flex justify-end">
+                      <button type="button" className="btn-primary" onClick={onClose}>
+                        Done
+                      </button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <Dialog.Title className="text-lg font-semibold text-gray-900">
+                      Reset password
+                    </Dialog.Title>
+                    <p className="mt-1 text-sm text-gray-600">
+                      Set a new password for{' '}
+                      <span className="font-medium text-gray-900">
+                        {userName || 'this user'}
+                      </span>
+                      {userEmail ? ` (${userEmail})` : ''}. You will need to pass it on
+                      to them yourself.
+                    </p>
+
+                    <div className="mt-4 space-y-3">
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700">
+                          New password
+                        </label>
+                        <input
+                          type={showPassword ? 'text' : 'password'}
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          autoComplete="new-password"
+                          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                          placeholder={`At least ${MIN_LENGTH} characters`}
+                        />
+                        {tooShort && (
+                          <p className="mt-1 text-xs text-red-600">
+                            Must be at least {MIN_LENGTH} characters.
+                          </p>
+                        )}
+                      </div>
+
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700">
+                          Confirm password
+                        </label>
+                        <input
+                          type={showPassword ? 'text' : 'password'}
+                          value={confirmPassword}
+                          onChange={(e) => setConfirmPassword(e.target.value)}
+                          autoComplete="new-password"
+                          className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary focus:outline-none"
+                        />
+                        {mismatch && (
+                          <p className="mt-1 text-xs text-red-600">
+                            Passwords do not match.
+                          </p>
+                        )}
+                      </div>
+
+                      <label className="flex items-center gap-2 text-sm text-gray-600">
+                        <input
+                          type="checkbox"
+                          checked={showPassword}
+                          onChange={(e) => setShowPassword(e.target.checked)}
+                        />
+                        Show password
+                      </label>
+                    </div>
+
+                    {error && (
+                      <p className="mt-3 rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                        {error}
+                      </p>
+                    )}
+
+                    <div className="mt-6 flex justify-end gap-2">
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={onClose}
+                        disabled={isLoading}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-primary"
+                        onClick={handleSubmit}
+                        disabled={!canSubmit}
+                      >
+                        {isLoading ? 'Saving…' : 'Set password'}
+                      </button>
+                    </div>
+                  </>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -13,6 +13,7 @@ interface UserCardProps {
   onAssignChild?: (userId: number) => void;
   onUnassignChild?: (userId: number, playerId: number) => void;
   onResendSetupEmail?: (userId: number) => void;
+  onResetPassword?: (userId: number) => void;
   showActions?: boolean;
   isSelectable?: boolean;
   isSelected?: boolean;
@@ -31,6 +32,7 @@ export default function UserCard({
   onAssignChild,
   onUnassignChild,
   onResendSetupEmail,
+  onResetPassword,
   showActions = true,
   isSelectable = false,
   isSelected = false,
@@ -315,6 +317,19 @@ export default function UserCard({
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
               </svg>
+            </button>
+          )}
+
+          {onResetPassword && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onResetPassword(user.id);
+              }}
+              className="btn-secondary btn-sm"
+              title="Set a new password for this user"
+            >
+              Reset Password
             </button>
           )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -336,6 +336,18 @@ export const usersAPI = {
     });
   },
 
+  // Admin sets a user's password directly, without an emailed token
+  resetPassword: async (
+    id: number,
+    password: string,
+    confirmPassword: string
+  ): Promise<UserResponse> => {
+    return apiRequest<UserResponse>(`/users/${id}/reset-password`, {
+      method: "POST",
+      body: JSON.stringify({ password, confirmPassword }),
+    });
+  },
+
   // Coach-specific endpoints
   getAvailableCoaches: async (): Promise<UserResponse[]> => {
     return apiRequest<UserResponse[]>("/users/coaches/available");


### PR DESCRIPTION
## Why

The only way to change a user's password was a token emailed to that person. That's no help when the mailbox is unreachable, the address is wrong, or an account is locked out.

## What

**`POST /api/users/{id}/reset-password`** — restricted to **ADMIN**. MANAGER is deliberately excluded: managers can already edit users, but handing over an account outright is a stronger capability. Easy to widen if you'd rather they had it.

`UserService.resetUserPassword` encodes the password, stamps `password_set_at`, and **invalidates outstanding setup/reset tokens**, so a link mailed out earlier can't later override what the admin just set.

**UI** — a `Reset Password` button on the admin user cards opens a modal that takes the password twice, enforces the same 8-character minimum as the token flow, and clears its fields between users so a password typed for one person can't leak into the next dialog.

## Verification

Against a running stack, not just a compile:

| Case | Result |
|---|---|
| Non-admin (PARENT) | 403 |
| Unauthenticated | 401 |
| Password under 8 chars | 400 |
| Confirmation mismatch | 400 |
| Unknown user | 404 |
| Valid admin reset | 200 |
| Old password afterwards | **401 rejected** |
| New password | **200 accepted** |
| Pending RESET token | **marked used** |

## Known limitation

JWTs already issued to the user stay valid until they expire (8h) — tokens are stateless and not tracked server-side, so a reset doesn't kick an active session. The modal states this rather than implying otherwise. Server-side token invalidation would be its own piece of work.

## Unrelated bug found while testing

`POST /auth/forgot-password` creates the token and sends the email in one transaction, so **a failed mail send rolls back the token insert**. In production, a transient SMTP outage means the user gets no email *and* no token — the reset silently does nothing. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)