### PR TITLE
Assess players against a template assigned to their group

### DIFF
--- a/backend/src/main/java/com/batal/controller/AssessmentController.java
+++ b/backend/src/main/java/com/batal/controller/AssessmentController.java
@@ -1,9 +1,12 @@
 package com.batal.controller;
 
 import com.batal.dto.*;
+import com.batal.exception.ValidationException;
 import com.batal.service.AssessmentService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -17,6 +20,8 @@ import java.util.Map;
 @RestController
 @RequestMapping("/assessments")
 public class AssessmentController {
+
+    private static final Logger logger = LoggerFactory.getLogger(AssessmentController.class);
 
     @Autowired
     private AssessmentService assessmentService;
@@ -53,7 +58,18 @@ public class AssessmentController {
                 "status", 404
             );
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+        } catch (ValidationException e) {
+            // Carries the reason the coach needs, such as the player's group
+            // having no assessment template. Caught before the catch-all below,
+            // which would otherwise reduce it to "an unexpected error".
+            Map<String, Object> errorResponse = Map.of(
+                "error", "Bad Request",
+                "message", e.getMessage(),
+                "status", 400
+            );
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         } catch (Exception e) {
+            logger.error("Unexpected error creating assessment", e);
             Map<String, Object> errorResponse = Map.of(
                 "error", "Internal Server Error",
                 "message", "An unexpected error occurred",
@@ -184,9 +200,10 @@ public class AssessmentController {
             return ResponseEntity.ok(response);
         } catch (SecurityException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } catch (IllegalStateException | IllegalArgumentException e) {
+        } catch (IllegalStateException | IllegalArgumentException | ValidationException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         } catch (Exception e) {
+            logger.error("Unexpected error updating assessment {}", id, e);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }

--- a/backend/src/main/java/com/batal/controller/AssessmentTemplateController.java
+++ b/backend/src/main/java/com/batal/controller/AssessmentTemplateController.java
@@ -1,0 +1,75 @@
+package com.batal.controller;
+
+import com.batal.dto.AssessmentTemplateRequest;
+import com.batal.dto.AssessmentTemplateResponse;
+import com.batal.service.AssessmentTemplateService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Assessment templates: the named sets of skills assigned to groups.
+ */
+@RestController
+@RequestMapping("/assessment-templates")
+@CrossOrigin(origins = "*", maxAge = 3600)
+public class AssessmentTemplateController {
+
+    @Autowired
+    private AssessmentTemplateService templateService;
+
+    /**
+     * Coaches need this to score, so any authenticated user may read templates.
+     * activeOnly=true is what the group assignment picker wants.
+     */
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<AssessmentTemplateResponse>> getAllTemplates(
+            @RequestParam(defaultValue = "false") boolean activeOnly) {
+        return ResponseEntity.ok(templateService.getAllTemplates(activeOnly));
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AssessmentTemplateResponse> getTemplateById(@PathVariable Long id) {
+        return ResponseEntity.ok(templateService.getTemplateById(id));
+    }
+
+    /**
+     * The template a player will be assessed against, inherited from their
+     * group. This is what the assessment form loads its skills from.
+     */
+    @GetMapping("/for-player/{playerId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AssessmentTemplateResponse> getTemplateForPlayer(@PathVariable Long playerId) {
+        return ResponseEntity.ok(templateService.getTemplateForPlayer(playerId));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<AssessmentTemplateResponse> createTemplate(
+            @Valid @RequestBody AssessmentTemplateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(templateService.createTemplate(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<AssessmentTemplateResponse> updateTemplate(
+            @PathVariable Long id,
+            @Valid @RequestBody AssessmentTemplateRequest request) {
+        return ResponseEntity.ok(templateService.updateTemplate(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String, String>> deleteTemplate(@PathVariable Long id) {
+        templateService.deleteTemplate(id);
+        return ResponseEntity.ok(Map.of("message", "Assessment template deleted successfully"));
+    }
+}

--- a/backend/src/main/java/com/batal/controller/GroupController.java
+++ b/backend/src/main/java/com/batal/controller/GroupController.java
@@ -198,6 +198,15 @@ public class GroupController {
         }
     }
 
+    // DELETE /api/groups/{groupId}/assessment-template - Unassign the template.
+    // Separate from the update endpoint, where a null id means "leave it alone".
+    // Note this blocks assessments for every player in the group.
+    @DeleteMapping("/{groupId}/assessment-template")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<GroupResponse> removeAssessmentTemplateFromGroup(@PathVariable Long groupId) {
+        return ResponseEntity.ok(groupService.removeAssessmentTemplateFromGroup(groupId));
+    }
+
     // GET /api/groups/coach/{coachId} - Get coach's assigned groups
     @GetMapping("/coach/{coachId}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER') or (hasRole('COACH') and @groupController.isCurrentUserCoach(#coachId))")

--- a/backend/src/main/java/com/batal/dto/AssessmentTemplateRequest.java
+++ b/backend/src/main/java/com/batal/dto/AssessmentTemplateRequest.java
@@ -1,0 +1,45 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Create or update an assessment template.
+ *
+ * Carries no age or level: both describe the group, and a template reaches
+ * players only by being assigned to one.
+ */
+public class AssessmentTemplateRequest {
+
+    @NotBlank(message = "Title is required")
+    @Size(max = 150, message = "Title must not exceed 150 characters")
+    private String title;
+
+    @Size(max = 1000, message = "Description must not exceed 1000 characters")
+    private String description;
+
+    /**
+     * The skills to assess, in the order they should be scored. A template
+     * with no skills would block every assessment for its groups, so at least
+     * one is required.
+     */
+    @NotEmpty(message = "Pick at least one skill")
+    private List<Long> skillIds;
+
+    private Boolean isActive = true;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public List<Long> getSkillIds() { return skillIds; }
+    public void setSkillIds(List<Long> skillIds) { this.skillIds = skillIds; }
+
+    public Boolean getIsActive() { return isActive; }
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
+}

--- a/backend/src/main/java/com/batal/dto/AssessmentTemplateResponse.java
+++ b/backend/src/main/java/com/batal/dto/AssessmentTemplateResponse.java
@@ -1,0 +1,63 @@
+package com.batal.dto;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AssessmentTemplateResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private Boolean isActive;
+    private List<SkillResponse> skills = new ArrayList<>();
+    private Integer skillCount;
+
+    /**
+     * Groups currently using this template. Shown so an admin can see the
+     * blast radius before editing or retiring it.
+     */
+    private List<String> assignedGroupNames = new ArrayList<>();
+    private Integer assignedGroupCount;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public AssessmentTemplateResponse() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public Boolean getIsActive() { return isActive; }
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
+
+    public List<SkillResponse> getSkills() { return skills; }
+    public void setSkills(List<SkillResponse> skills) {
+        this.skills = skills;
+        this.skillCount = skills != null ? skills.size() : 0;
+    }
+
+    public Integer getSkillCount() { return skillCount; }
+    public void setSkillCount(Integer skillCount) { this.skillCount = skillCount; }
+
+    public List<String> getAssignedGroupNames() { return assignedGroupNames; }
+    public void setAssignedGroupNames(List<String> assignedGroupNames) {
+        this.assignedGroupNames = assignedGroupNames;
+        this.assignedGroupCount = assignedGroupNames != null ? assignedGroupNames.size() : 0;
+    }
+
+    public Integer getAssignedGroupCount() { return assignedGroupCount; }
+    public void setAssignedGroupCount(Integer assignedGroupCount) { this.assignedGroupCount = assignedGroupCount; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/src/main/java/com/batal/dto/GroupCreateRequest.java
+++ b/backend/src/main/java/com/batal/dto/GroupCreateRequest.java
@@ -23,6 +23,9 @@ public class GroupCreateRequest {
     private Integer capacity = 15;
     
     private Long coachId;
+
+    /** Which template defines what this group's players are assessed on. */
+    private Long assessmentTemplateId;
     
     private Long pitchId;
     
@@ -143,5 +146,13 @@ public class GroupCreateRequest {
 
     public void setIsActive(Boolean isActive) {
         this.isActive = isActive;
+    }
+
+    public Long getAssessmentTemplateId() {
+        return assessmentTemplateId;
+    }
+
+    public void setAssessmentTemplateId(Long assessmentTemplateId) {
+        this.assessmentTemplateId = assessmentTemplateId;
     }
 }

--- a/backend/src/main/java/com/batal/dto/GroupResponse.java
+++ b/backend/src/main/java/com/batal/dto/GroupResponse.java
@@ -27,6 +27,11 @@ public class GroupResponse {
     private LocalDateTime updatedAt;
     
     // Coach information
+    // Assessment template. Null means assessments are blocked for this group's
+    // players until one is assigned.
+    private Long assessmentTemplateId;
+    private String assessmentTemplateTitle;
+
     private UserResponse coach;
 
     // Player information
@@ -52,6 +57,12 @@ public class GroupResponse {
         this.createdAt = group.getCreatedAt();
         this.updatedAt = group.getUpdatedAt();
         
+        // Set assessment template if one is assigned
+        if (group.getAssessmentTemplate() != null) {
+            this.assessmentTemplateId = group.getAssessmentTemplate().getId();
+            this.assessmentTemplateTitle = group.getAssessmentTemplate().getTitle();
+        }
+
         // Set coach information if present
         if (group.getCoach() != null) {
             this.coach = new UserResponse(group.getCoach(),
@@ -187,6 +198,22 @@ public class GroupResponse {
         this.updatedAt = updatedAt;
     }
     
+    public Long getAssessmentTemplateId() {
+        return assessmentTemplateId;
+    }
+
+    public void setAssessmentTemplateId(Long assessmentTemplateId) {
+        this.assessmentTemplateId = assessmentTemplateId;
+    }
+
+    public String getAssessmentTemplateTitle() {
+        return assessmentTemplateTitle;
+    }
+
+    public void setAssessmentTemplateTitle(String assessmentTemplateTitle) {
+        this.assessmentTemplateTitle = assessmentTemplateTitle;
+    }
+
     public UserResponse getCoach() {
         return coach;
     }

--- a/backend/src/main/java/com/batal/dto/GroupUpdateRequest.java
+++ b/backend/src/main/java/com/batal/dto/GroupUpdateRequest.java
@@ -18,6 +18,9 @@ public class GroupUpdateRequest {
     private Integer capacity;
     
     private Long coachId;
+
+    /** Which template defines what this group's players are assessed on. */
+    private Long assessmentTemplateId;
     
     private Long pitchId;
     
@@ -126,5 +129,13 @@ public class GroupUpdateRequest {
     
     public void setMaxAge(Integer maxAge) {
         this.maxAge = maxAge;
+    }
+
+    public Long getAssessmentTemplateId() {
+        return assessmentTemplateId;
+    }
+
+    public void setAssessmentTemplateId(Long assessmentTemplateId) {
+        this.assessmentTemplateId = assessmentTemplateId;
     }
 }

--- a/backend/src/main/java/com/batal/entity/AssessmentTemplate.java
+++ b/backend/src/main/java/com/batal/entity/AssessmentTemplate.java
@@ -1,0 +1,121 @@
+package com.batal.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * A titled set of skills that defines what a group's players are assessed on.
+ *
+ * This is the blueprint, not the result: {@link Assessment} holds one player's
+ * scored evaluation on a date. Keeping them apart means editing a template
+ * never rewrites assessments already recorded against it.
+ *
+ * Templates carry no age or level of their own. Both already describe the
+ * group, and a template reaches players only by being assigned to one.
+ */
+@Entity
+@Table(name = "assessment_templates",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"title"}))
+public class AssessmentTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 150)
+    @Column(nullable = false, length = 150)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    /**
+     * The skills this template covers.
+     *
+     * Ordered by the skill's own position in the library rather than the order
+     * they were picked, so the same skill sits in the same place across every
+     * template and the scoring form stays predictable. Eagerly fetched because
+     * every use of a template needs its skills.
+     */
+    @NotEmpty
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+        name = "assessment_template_skills",
+        joinColumns = @JoinColumn(name = "template_id"),
+        inverseJoinColumns = @JoinColumn(name = "skill_id")
+    )
+    @OrderBy("displayOrder ASC, name ASC")
+    private Set<Skill> skills = new LinkedHashSet<>();
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public AssessmentTemplate() {
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public boolean covers(Skill skill) {
+        return skills.contains(skill);
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public Set<Skill> getSkills() { return skills; }
+    public void setSkills(Set<Skill> skills) { this.skills = skills; }
+
+    public Boolean getIsActive() { return isActive; }
+    public void setIsActive(Boolean isActive) { this.isActive = isActive; }
+
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public LocalDateTime getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AssessmentTemplate)) return false;
+        AssessmentTemplate other = (AssessmentTemplate) o;
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "AssessmentTemplate{id=" + id + ", title='" + title + "'}";
+    }
+}

--- a/backend/src/main/java/com/batal/entity/Group.java
+++ b/backend/src/main/java/com/batal/entity/Group.java
@@ -53,6 +53,15 @@ public class Group {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coach_id")
     private User coach;
+
+    /**
+     * Defines the skills this group's players are assessed on. Null until an
+     * admin assigns one, and assessments are blocked while it is null rather
+     * than falling back to some arbitrary set of skills.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assessment_template_id")
+    private AssessmentTemplate assessmentTemplate;
     
     // Players are now managed through Player entities
     @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
@@ -153,6 +162,14 @@ public class Group {
         this.capacity = capacity;
     }
     
+    public AssessmentTemplate getAssessmentTemplate() {
+        return assessmentTemplate;
+    }
+
+    public void setAssessmentTemplate(AssessmentTemplate assessmentTemplate) {
+        this.assessmentTemplate = assessmentTemplate;
+    }
+
     public User getCoach() {
         return coach;
     }

--- a/backend/src/main/java/com/batal/event/PasswordSetupEmailListener.java
+++ b/backend/src/main/java/com/batal/event/PasswordSetupEmailListener.java
@@ -5,8 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -32,12 +30,17 @@ public class PasswordSetupEmailListener {
     private AuthService authService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onPasswordSetupEmailRequested(PasswordSetupEmailRequestedEvent event) {
         try {
-            authService.sendPasswordSetupEmail(event.getUserId());
+            // Opens its own transaction and handles a mail failure internally,
+            // so nothing here can mark a transaction rollback-only.
+            if (!authService.issuePasswordSetupLink(event.getUserId())) {
+                log.error("Could not email a password setup link to user {}. "
+                        + "The account exists and the link is still valid, so an "
+                        + "admin can resend it.", event.getUserId());
+            }
         } catch (Exception e) {
-            log.error("Failed to send password setup email to user {}. "
+            log.error("Failed to issue a password setup link for user {}. "
                     + "The account was created; an admin can resend the link.",
                     event.getUserId(), e);
         }

--- a/backend/src/main/java/com/batal/repository/AssessmentTemplateRepository.java
+++ b/backend/src/main/java/com/batal/repository/AssessmentTemplateRepository.java
@@ -1,0 +1,31 @@
+package com.batal.repository;
+
+import com.batal.entity.AssessmentTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AssessmentTemplateRepository extends JpaRepository<AssessmentTemplate, Long> {
+
+    boolean existsByTitleIgnoreCase(String title);
+
+    Optional<AssessmentTemplate> findByTitleIgnoreCase(String title);
+
+    @Query("SELECT DISTINCT t FROM AssessmentTemplate t LEFT JOIN FETCH t.skills ORDER BY t.title ASC")
+    List<AssessmentTemplate> findAllWithSkills();
+
+    @Query("SELECT DISTINCT t FROM AssessmentTemplate t LEFT JOIN FETCH t.skills WHERE t.isActive = true ORDER BY t.title ASC")
+    List<AssessmentTemplate> findActiveWithSkills();
+
+    /** Groups currently pointing at this template, so it is not edited or retired blindly. */
+    @Query("SELECT g.name FROM Group g WHERE g.assessmentTemplate.id = :templateId ORDER BY g.name ASC")
+    List<String> findAssignedGroupNames(@Param("templateId") Long templateId);
+
+    @Query("SELECT COUNT(g) FROM Group g WHERE g.assessmentTemplate.id = :templateId")
+    long countAssignedGroups(@Param("templateId") Long templateId);
+}

--- a/backend/src/main/java/com/batal/service/AssessmentService.java
+++ b/backend/src/main/java/com/batal/service/AssessmentService.java
@@ -55,8 +55,8 @@ public class AssessmentService {
         // Check for duplicate assessments in the same month
         validateNoDuplicateAssessment(player, request.getAssessmentDate(), null);
 
-        // Validate skills belong to player's level
-        validateSkillsForPlayerLevel(request.getSkillRatings(), player.getLevel());
+        // Validate skills against the template assigned to the player's group
+        validateSkillsAgainstTemplate(request.getSkillRatings(), player);
 
         // Create assessment
         Assessment assessment = new Assessment();
@@ -201,7 +201,7 @@ public class AssessmentService {
 
         // Update skill scores if provided
         if (request.getSkillRatings() != null) {
-            validateSkillsForPlayerLevel(request.getSkillRatings(), assessment.getPlayer().getLevel());
+            validateSkillsAgainstTemplate(request.getSkillRatings(), assessment.getPlayer());
             updateSkillScores(assessment, request.getSkillRatings());
         }
 
@@ -522,7 +522,39 @@ public class AssessmentService {
         }
     }
 
-    private void validateSkillsForPlayerLevel(List<SkillRatingRequest> skillRatings, Level playerLevel) {
+    /**
+     * The skills a player can be scored on: exactly those in the assessment
+     * template assigned to their group.
+     *
+     * A player with no group, or a group with no template, cannot be assessed.
+     * Falling back to every skill for their level would silently produce an
+     * assessment nobody chose the contents of.
+     */
+    private Set<Skill> requireTemplateSkills(Player player) {
+        Group group = player.getGroup();
+        if (group == null) {
+            throw new ValidationException(
+                    player.getFullName() + " is not in a group, so there is no assessment template to use. "
+                            + "Assign them to a group first.");
+        }
+
+        AssessmentTemplate template = group.getAssessmentTemplate();
+        if (template == null) {
+            throw new ValidationException(
+                    "Group \"" + group.getName() + "\" has no assessment template assigned, "
+                            + "so its players cannot be assessed yet. "
+                            + "Assign one by editing the group.");
+        }
+
+        return template.getSkills();
+    }
+
+    private void validateSkillsAgainstTemplate(List<SkillRatingRequest> skillRatings, Player player) {
+        Set<Skill> templateSkills = requireTemplateSkills(player);
+        Set<Long> allowedSkillIds = templateSkills.stream()
+                .map(Skill::getId)
+                .collect(Collectors.toSet());
+
         List<Long> skillIds = skillRatings.stream()
                 .map(SkillRatingRequest::getSkillId)
                 .collect(Collectors.toList());
@@ -534,20 +566,16 @@ public class AssessmentService {
         }
 
         for (Skill skill : skills) {
-            if (!skill.isApplicableForLevel(playerLevel)) {
+            if (!allowedSkillIds.contains(skill.getId())) {
                 throw new ValidationException(
-                        "Skill '" + skill.getName() + "' is not applicable for " + playerLevel + " level");
-            }
-            if (!skill.getIsActive()) {
-                throw new ValidationException(
-                        "Skill '" + skill.getName() + "' is not active");
+                        "Skill '" + skill.getName() + "' is not part of the assessment template for "
+                                + player.getGroup().getName() + ".");
             }
         }
     }
 
     private boolean isAssessmentComplete(Assessment assessment) {
-        Level playerLevel = assessment.getPlayer().getLevel();
-        List<Skill> requiredSkills = skillRepository.findByApplicableLevelsContainingAndIsActiveTrue(playerLevel);
+        Set<Skill> requiredSkills = requireTemplateSkills(assessment.getPlayer());
 
         Set<Long> assessedSkillIds = assessment.getSkillScores().stream()
                 .map(ss -> ss.getSkill().getId())
@@ -563,8 +591,7 @@ public class AssessmentService {
 
     private void validateAssessmentComplete(Assessment assessment) {
         if (!isAssessmentComplete(assessment)) {
-            Level playerLevel = assessment.getPlayer().getLevel();
-            List<Skill> requiredSkills = skillRepository.findByApplicableLevelsContainingAndIsActiveTrue(playerLevel);
+            Set<Skill> requiredSkills = requireTemplateSkills(assessment.getPlayer());
 
             Set<Long> assessedSkillIds = assessment.getSkillScores().stream()
                     .map(ss -> ss.getSkill().getId())

--- a/backend/src/main/java/com/batal/service/AssessmentTemplateService.java
+++ b/backend/src/main/java/com/batal/service/AssessmentTemplateService.java
@@ -1,0 +1,213 @@
+package com.batal.service;
+
+import com.batal.dto.AssessmentTemplateRequest;
+import com.batal.dto.AssessmentTemplateResponse;
+import com.batal.dto.SkillResponse;
+import com.batal.entity.AssessmentTemplate;
+import com.batal.entity.Group;
+import com.batal.entity.Player;
+import com.batal.entity.Skill;
+import com.batal.exception.BusinessRuleException;
+import com.batal.exception.ResourceAlreadyExistsException;
+import com.batal.exception.ResourceNotFoundException;
+import com.batal.repository.AssessmentTemplateRepository;
+import com.batal.repository.PlayerRepository;
+import com.batal.repository.SkillRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Manages assessment templates: the named sets of skills that decide what a
+ * group's players are scored on.
+ */
+@Service
+@Transactional
+public class AssessmentTemplateService {
+
+    @Autowired
+    private AssessmentTemplateRepository templateRepository;
+
+    @Autowired
+    private SkillRepository skillRepository;
+
+    @Autowired
+    private PlayerRepository playerRepository;
+
+    @Transactional(readOnly = true)
+    public List<AssessmentTemplateResponse> getAllTemplates(boolean activeOnly) {
+        List<AssessmentTemplate> templates = activeOnly
+                ? templateRepository.findActiveWithSkills()
+                : templateRepository.findAllWithSkills();
+        return templates.stream().map(this::toResponse).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public AssessmentTemplateResponse getTemplateById(Long id) {
+        return toResponse(requireTemplate(id));
+    }
+
+    /**
+     * The template a given player will be assessed against, inherited from
+     * their group.
+     *
+     * Fails with a message the coach can act on rather than returning an empty
+     * list, because an empty skill list is indistinguishable from a template
+     * that genuinely has none.
+     */
+    @Transactional(readOnly = true)
+    public AssessmentTemplateResponse getTemplateForPlayer(Long playerId) {
+        Player player = playerRepository.findById(playerId)
+                .orElseThrow(() -> new ResourceNotFoundException("Player", playerId));
+
+        Group group = player.getGroup();
+        if (group == null) {
+            throw new BusinessRuleException(
+                    player.getFullName() + " is not in a group, so there is no assessment template to use. "
+                            + "Assign them to a group first.");
+        }
+
+        AssessmentTemplate template = group.getAssessmentTemplate();
+        if (template == null) {
+            throw new BusinessRuleException(
+                    "Group \"" + group.getName() + "\" has no assessment template assigned, "
+                            + "so its players cannot be assessed yet. "
+                            + "Assign one by editing the group.");
+        }
+
+        return toResponse(template);
+    }
+
+    public AssessmentTemplateResponse createTemplate(AssessmentTemplateRequest request) {
+        String title = request.getTitle().trim();
+        if (templateRepository.existsByTitleIgnoreCase(title)) {
+            throw new ResourceAlreadyExistsException("Assessment template", "title", title);
+        }
+
+        AssessmentTemplate template = new AssessmentTemplate();
+        template.setTitle(title);
+        template.setDescription(trimToNull(request.getDescription()));
+        template.setSkills(resolveSkills(request.getSkillIds()));
+        template.setIsActive(request.getIsActive() == null || request.getIsActive());
+
+        return toResponse(templateRepository.save(template));
+    }
+
+    public AssessmentTemplateResponse updateTemplate(Long id, AssessmentTemplateRequest request) {
+        AssessmentTemplate template = requireTemplate(id);
+
+        String title = request.getTitle().trim();
+        if (!template.getTitle().equalsIgnoreCase(title)
+                && templateRepository.existsByTitleIgnoreCase(title)) {
+            throw new ResourceAlreadyExistsException("Assessment template", "title", title);
+        }
+
+        boolean deactivating = request.getIsActive() != null && !request.getIsActive();
+        if (deactivating) {
+            // Deactivating a template that groups still point at would block
+            // their assessments with no obvious cause.
+            requireNotInUse(template, "deactivated");
+        }
+
+        template.setTitle(title);
+        template.setDescription(trimToNull(request.getDescription()));
+        template.setSkills(resolveSkills(request.getSkillIds()));
+        template.setIsActive(request.getIsActive() == null || request.getIsActive());
+
+        return toResponse(templateRepository.save(template));
+    }
+
+    public void deleteTemplate(Long id) {
+        AssessmentTemplate template = requireTemplate(id);
+        requireNotInUse(template, "deleted");
+        templateRepository.delete(template);
+    }
+
+    /** Skills, in the order given, rejecting unknown or inactive ones. */
+    private Set<Skill> resolveSkills(List<Long> skillIds) {
+        List<Long> distinctIds = skillIds.stream().distinct().collect(Collectors.toList());
+
+        Map<Long, Skill> found = skillRepository.findAllById(distinctIds).stream()
+                .collect(Collectors.toMap(Skill::getId, Function.identity()));
+
+        List<Long> missing = distinctIds.stream()
+                .filter(skillId -> !found.containsKey(skillId))
+                .collect(Collectors.toList());
+        if (!missing.isEmpty()) {
+            throw new ResourceNotFoundException("Skill", missing.get(0));
+        }
+
+        List<String> inactive = found.values().stream()
+                .filter(skill -> !Boolean.TRUE.equals(skill.getIsActive()))
+                .map(Skill::getName)
+                .collect(Collectors.toList());
+        if (!inactive.isEmpty()) {
+            throw new BusinessRuleException(
+                    "These skills are inactive and cannot be assessed: " + String.join(", ", inactive));
+        }
+
+        // Order here is not significant: the entity reads skills back in the
+        // library's own order so a skill sits in the same place everywhere.
+        return distinctIds.stream()
+                .map(found::get)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private void requireNotInUse(AssessmentTemplate template, String action) {
+        List<String> groups = templateRepository.findAssignedGroupNames(template.getId());
+        if (!groups.isEmpty()) {
+            throw new BusinessRuleException(
+                    "\"" + template.getTitle() + "\" cannot be " + action
+                            + " while it is assigned to " + groups.size() + " group(s): "
+                            + String.join(", ", groups)
+                            + ". Assign those groups a different template first.");
+        }
+    }
+
+    private AssessmentTemplate requireTemplate(Long id) {
+        return templateRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Assessment template", id));
+    }
+
+    private AssessmentTemplateResponse toResponse(AssessmentTemplate template) {
+        AssessmentTemplateResponse response = new AssessmentTemplateResponse();
+        response.setId(template.getId());
+        response.setTitle(template.getTitle());
+        response.setDescription(template.getDescription());
+        response.setIsActive(template.getIsActive());
+
+        List<SkillResponse> skills = new ArrayList<>();
+        for (Skill skill : template.getSkills()) {
+            SkillResponse skillResponse = new SkillResponse();
+            skillResponse.setId(skill.getId());
+            skillResponse.setName(skill.getName());
+            skillResponse.setCategory(skill.getCategory());
+            skillResponse.setApplicableLevels(skill.getApplicableLevels());
+            skillResponse.setDescription(skill.getDescription());
+            skillResponse.setDisplayOrder(skill.getDisplayOrder());
+            skillResponse.setIsActive(skill.getIsActive());
+            skills.add(skillResponse);
+        }
+        response.setSkills(skills);
+        response.setAssignedGroupNames(templateRepository.findAssignedGroupNames(template.getId()));
+        response.setCreatedAt(template.getCreatedAt());
+        response.setUpdatedAt(template.getUpdatedAt());
+        return response;
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/backend/src/main/java/com/batal/service/AuthService.java
+++ b/backend/src/main/java/com/batal/service/AuthService.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
@@ -287,6 +288,51 @@ public class AuthService {
         // Update last sent timestamp
         user.setPasswordSetupEmailLastSentAt(LocalDateTime.now());
         userRepository.save(user);
+    }
+
+    /**
+     * Issue a setup link for a newly created account, keeping a mail failure
+     * from taking the token with it.
+     *
+     * EmailService rethrows delivery failures. Letting that escape a
+     * transactional method marks the transaction rollback-only, and the caller
+     * then fails at commit with UnexpectedRollbackException even though it
+     * caught the original exception. Catching the failure inside the
+     * transaction means the token still commits and an admin can resend the
+     * link without reissuing it.
+     *
+     * @return true when the email was accepted for delivery
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean issuePasswordSetupLink(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        if (user.getPasswordSetAt() != null) {
+            throw new BusinessRuleException("User has already set their password");
+        }
+
+        tokenRepository.invalidateAllUserTokens(userId, LocalDateTime.now());
+
+        String tokenString = generateSecureToken();
+        PasswordSetupToken token = new PasswordSetupToken();
+        token.setUser(user);
+        token.setToken(tokenString);
+        token.setTokenType(TokenType.SETUP);
+        token.setExpiresAt(LocalDateTime.now().plusHours(tokenExpiryHours));
+        tokenRepository.save(token);
+
+        try {
+            emailService.sendPasswordSetupEmail(user, tokenString);
+        } catch (RuntimeException e) {
+            // Deliberately swallowed so this transaction is not poisoned. The
+            // caller logs it; the token stays valid for a resend.
+            return false;
+        }
+
+        user.setPasswordSetupEmailLastSentAt(LocalDateTime.now());
+        userRepository.save(user);
+        return true;
     }
 
     /**

--- a/backend/src/main/java/com/batal/service/GroupService.java
+++ b/backend/src/main/java/com/batal/service/GroupService.java
@@ -1,12 +1,16 @@
 package com.batal.service;
 
 import com.batal.dto.*;
+import com.batal.entity.AssessmentTemplate;
 import com.batal.entity.Group;
 import com.batal.entity.Player;
 import com.batal.entity.User;
 import com.batal.entity.enums.AgeGroup;
 import com.batal.entity.enums.Level;
 import com.batal.entity.enums.UserType;
+import com.batal.exception.BusinessRuleException;
+import com.batal.exception.ResourceNotFoundException;
+import com.batal.repository.AssessmentTemplateRepository;
 import com.batal.repository.GroupRepository;
 import com.batal.repository.PlayerRepository;
 import com.batal.repository.UserRepository;
@@ -27,6 +31,9 @@ public class GroupService {
 
     @Autowired
     private GroupRepository groupRepository;
+
+    @Autowired
+    private AssessmentTemplateRepository assessmentTemplateRepository;
 
     @Autowired
     private PlayerRepository playerRepository;
@@ -58,6 +65,11 @@ public class GroupService {
                 throw new RuntimeException("User is not a coach");
             }
             group.setCoach(coach);
+        }
+
+        // Assign assessment template if provided
+        if (request.getAssessmentTemplateId() != null) {
+            group.setAssessmentTemplate(requireActiveTemplate(request.getAssessmentTemplateId()));
         }
 
         Group savedGroup = groupRepository.save(group);
@@ -137,6 +149,13 @@ public class GroupService {
                 throw new RuntimeException("User is not a coach");
             }
             group.setCoach(coach);
+        }
+
+        // Update assessment template if provided. Null means "leave as is";
+        // clearing it goes through removeAssessmentTemplate, because dropping
+        // it blocks assessments for every player in the group.
+        if (request.getAssessmentTemplateId() != null) {
+            group.setAssessmentTemplate(requireActiveTemplate(request.getAssessmentTemplateId()));
         }
 
         group.setUpdatedAt(LocalDateTime.now());
@@ -239,6 +258,35 @@ public class GroupService {
 
         Group savedGroup = groupRepository.save(group);
         return new GroupResponse(savedGroup);
+    }
+
+    /**
+     * Unassign the group's assessment template.
+     *
+     * Separate from updateGroup because a null id there means "leave it alone",
+     * and because removing it blocks assessments for everyone in the group.
+     */
+    public GroupResponse removeAssessmentTemplateFromGroup(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new ResourceNotFoundException("Group", groupId));
+
+        group.setAssessmentTemplate(null);
+        group.setUpdatedAt(LocalDateTime.now());
+
+        Group savedGroup = groupRepository.save(group);
+        return new GroupResponse(savedGroup);
+    }
+
+    /** A template must exist and be active before a group can point at it. */
+    private AssessmentTemplate requireActiveTemplate(Long templateId) {
+        AssessmentTemplate template = assessmentTemplateRepository.findById(templateId)
+                .orElseThrow(() -> new ResourceNotFoundException("Assessment template", templateId));
+
+        if (!Boolean.TRUE.equals(template.getIsActive())) {
+            throw new BusinessRuleException(
+                    "Assessment template \"" + template.getTitle() + "\" is inactive and cannot be assigned.");
+        }
+        return template;
     }
 
     // Get available groups (with capacity)

--- a/backend/src/main/resources/db/migration/V48__Create_assessment_templates.sql
+++ b/backend/src/main/resources/db/migration/V48__Create_assessment_templates.sql
@@ -1,0 +1,63 @@
+-- Assessment templates: a named, curated set of skills assigned to a group.
+--
+-- Until now the skills a player was scored on were derived automatically from
+-- their level, so everyone at a level got the same list. A template lets an
+-- admin choose exactly which skills apply to a group.
+--
+-- This is NOT the same thing as the assessments table, which stores a single
+-- player's scored evaluation on a date. A template is the blueprint; an
+-- assessment is the filled-in result. They are kept apart so that editing a
+-- template never rewrites history.
+--
+-- Age and level are deliberately absent here. Both already describe the group,
+-- and a template reaches players only by being assigned to one.
+
+CREATE TABLE assessment_templates (
+    id          BIGSERIAL PRIMARY KEY,
+    title       VARCHAR(150) NOT NULL,
+    description TEXT,
+    is_active   BOOLEAN NOT NULL DEFAULT true,
+    created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    -- Titles are how an admin picks a template from a list, so duplicates
+    -- would make the choice ambiguous.
+    CONSTRAINT uq_assessment_template_title UNIQUE (title)
+);
+
+COMMENT ON TABLE assessment_templates IS
+    'A titled set of skills that defines what a group''s players are assessed on.';
+
+-- The skills making up a template. Scoring lists them in the library's own
+-- order, so a skill sits in the same place across every template and no
+-- per-template ordering is stored here.
+CREATE TABLE assessment_template_skills (
+    template_id BIGINT NOT NULL,
+    skill_id    BIGINT NOT NULL,
+
+    PRIMARY KEY (template_id, skill_id),
+    CONSTRAINT fk_template_skills_template FOREIGN KEY (template_id)
+        REFERENCES assessment_templates (id) ON DELETE CASCADE,
+    -- A skill that is part of a template cannot be deleted out from under it.
+    CONSTRAINT fk_template_skills_skill FOREIGN KEY (skill_id)
+        REFERENCES skills (id) ON DELETE RESTRICT
+);
+
+CREATE INDEX idx_template_skills_template ON assessment_template_skills (template_id);
+CREATE INDEX idx_template_skills_skill    ON assessment_template_skills (skill_id);
+
+-- A group has at most one template. Assessments for its players are blocked
+-- until one is assigned, so this stays nullable rather than defaulting to
+-- something arbitrary.
+ALTER TABLE groups
+    ADD COLUMN assessment_template_id BIGINT;
+
+ALTER TABLE groups
+    ADD CONSTRAINT fk_groups_assessment_template FOREIGN KEY (assessment_template_id)
+        REFERENCES assessment_templates (id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_groups_assessment_template ON groups (assessment_template_id);
+
+COMMENT ON COLUMN groups.assessment_template_id IS
+    'Which template defines the skills this group''s players are assessed on. '
+    'Null means assessments cannot be created for them yet.';

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -18,6 +18,7 @@ import DeleteConfirmationModal from '@/components/DeleteConfirmationModal';
 import ResetPasswordModal from '@/components/ResetPasswordModal';
 import ReassignPlayerModal from '@/components/ReassignPlayerModal';
 import SkillsManagement from '@/components/skills/SkillsManagement';
+import AssessmentTemplateManagement from '@/components/assessments/AssessmentTemplateManagement';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import LogoutButton from '@/components/LogoutButton';
 import { useAuth } from '@/store/hooks';
@@ -36,7 +37,7 @@ export default function AdminDashboard() {
   const { showError, showSuccess } = useNotification();
   
   // State
-  const [activeTab, setActiveTab] = useState<'overview' | 'groups' | 'users' | 'parents' | 'players' | 'skills'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'groups' | 'users' | 'parents' | 'players' | 'assessments' | 'skills'>('overview');
   const [loading, setLoading] = useState(true);
 
   // Data. `users` is academy staff only; parents are listed separately.
@@ -230,6 +231,17 @@ export default function AdminDashboard() {
       showError(errorMessage, 'Users Data Error');
     }
   }, [usersPagination.page, usersPagination.size, usersPagination.sortBy, usersPagination.sortDir, usersPagination.search, showError]);
+
+  // Groups carry their assigned assessment template, so anything that changes
+  // templates or assignments needs them re-read.
+  const loadGroupsData = useCallback(async () => {
+    try {
+      setGroups(await groupsAPI.getAll());
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load groups';
+      showError(errorMessage, 'Groups Data Error');
+    }
+  }, [showError]);
 
   const loadParentsData = useCallback(async () => {
     try {
@@ -928,10 +940,11 @@ export default function AdminDashboard() {
             { id: 'users', label: 'Staff', icon: <span>🧑‍💼</span> },
             { id: 'parents', label: 'Parents', icon: <span>👪</span> },
             { id: 'players', label: 'Players', icon: <span>⚽</span> },
+            { id: 'assessments', label: 'Assessments', icon: <span>📝</span> },
             { id: 'skills', label: 'Skills', icon: <span>🎯</span> }
           ]}
           activeTab={activeTab}
-          onChange={(tabId) => setActiveTab(tabId as 'overview' | 'groups' | 'users' | 'parents' | 'players' | 'skills')}
+          onChange={(tabId) => setActiveTab(tabId as 'overview' | 'groups' | 'users' | 'parents' | 'players' | 'assessments' | 'skills')}
           className="mb-6 sm:mb-8"
         />
 
@@ -1300,6 +1313,17 @@ export default function AdminDashboard() {
                 </div>
               )}
             </div>
+          )}
+
+          {activeTab === 'assessments' && (
+            <AssessmentTemplateManagement
+              onError={(message) => showError(message, 'Assessment Error')}
+              onSuccess={showSuccess}
+              groupsWithoutTemplate={groups
+                .filter(group => group.isActive && !group.assessmentTemplateId)
+                .map(group => group.name)}
+              onTemplatesChanged={loadGroupsData}
+            />
           )}
 
           {activeTab === 'skills' && (

--- a/frontend/src/components/CreateGroupModal.tsx
+++ b/frontend/src/components/CreateGroupModal.tsx
@@ -6,6 +6,7 @@ import { GroupResponse, GroupCreateRequest, AgeGroup, AGE_GROUP_METADATA } from 
 import { Level } from '@/types/players';
 import { UserResponse, UserType } from '@/types/users';
 import { apiClient } from '@/lib/apiClient';
+import AssessmentTemplateSelect from '@/components/assessments/AssessmentTemplateSelect';
 import { groupsAPI, usersAPI } from '@/lib/api';
 
 interface CreateGroupModalProps {
@@ -25,6 +26,7 @@ export default function CreateGroupModal({
     ageGroup: AgeGroup.COOKIES,
     capacity: 20,
     coachId: undefined,
+    assessmentTemplateId: undefined as number | undefined,
     zone: '',
     description: '',
     isActive: true
@@ -79,6 +81,7 @@ export default function CreateGroupModal({
       ageGroup: AgeGroup.COOKIES,
       capacity: 20,
       coachId: undefined,
+      assessmentTemplateId: undefined,
       zone: '',
       description: '',
       isActive: true
@@ -402,6 +405,12 @@ export default function CreateGroupModal({
                       </p>
                     )}
                   </div>
+
+                  {/* Assessment template */}
+                  <AssessmentTemplateSelect
+                    value={formData.assessmentTemplateId}
+                    onChange={(assessmentTemplateId) => setFormData({...formData, assessmentTemplateId})}
+                  />
 
                   {/* Status */}
                   <div className="alert-success">

--- a/frontend/src/components/EditGroupModal.tsx
+++ b/frontend/src/components/EditGroupModal.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useState, useEffect } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { GroupResponse, AgeGroup, Level, AGE_GROUP_METADATA } from '@/types/groups';
+import AssessmentTemplateSelect from '@/components/assessments/AssessmentTemplateSelect';
 import { groupsAPI } from '@/lib/api';
 
 interface EditGroupModalProps {
@@ -25,8 +26,13 @@ export default function EditGroupModal({
     capacity: 20,
     zone: '',
     description: '',
-    isActive: true
+    isActive: true,
+    assessmentTemplateId: undefined as number | undefined
   });
+
+  // Remembered so clearing the template can be told apart from leaving it be:
+  // the update endpoint treats a null id as "no change".
+  const [originalTemplateId, setOriginalTemplateId] = useState<number | undefined>(undefined);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -52,8 +58,10 @@ export default function EditGroupModal({
         capacity: group.capacity || 20,
         zone: group.zone || '',
         description: group.description || '',
-        isActive: group.isActive
+        isActive: group.isActive,
+        assessmentTemplateId: group.assessmentTemplateId ?? undefined
       });
+      setOriginalTemplateId(group.assessmentTemplateId ?? undefined);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load group data');
     } finally {
@@ -69,7 +77,14 @@ export default function EditGroupModal({
     setError(null);
 
     try {
-      const updatedGroup = await groupsAPI.update(groupId, formData);
+      let updatedGroup = await groupsAPI.update(groupId, formData);
+
+      // A null id means "leave it alone" to the update endpoint, so removing
+      // the template needs its own call.
+      if (originalTemplateId !== undefined && formData.assessmentTemplateId === undefined) {
+        updatedGroup = await groupsAPI.removeAssessmentTemplate(groupId);
+      }
+
       onComplete(updatedGroup);
       handleClose();
     } catch (err) {
@@ -88,8 +103,10 @@ export default function EditGroupModal({
       capacity: 20,
       zone: '',
       description: '',
-      isActive: true
+      isActive: true,
+      assessmentTemplateId: undefined
     });
+    setOriginalTemplateId(undefined);
     setError(null);
     onClose();
   };
@@ -307,6 +324,12 @@ export default function EditGroupModal({
                       placeholder="Optional description for this group..."
                     />
                   </div>
+
+                  {/* Assessment template */}
+                  <AssessmentTemplateSelect
+                    value={formData.assessmentTemplateId}
+                    onChange={(assessmentTemplateId) => setFormData({...formData, assessmentTemplateId})}
+                  />
 
                   {/* Status */}
                   <div>

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -244,6 +244,24 @@ export default function GroupCard({
         )}
       </div>
 
+      {/* Assessment. Without one, this group's players cannot be assessed at
+          all, so its absence is called out rather than left blank. */}
+      <div className="mb-4">
+        <div className="flex items-center text-primary mb-1">
+          <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+            <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
+          </svg>
+          <span className="text-sm font-medium">Assessment</span>
+        </div>
+        {group.assessmentTemplateTitle ? (
+          <p className="text-sm text-text-primary">{group.assessmentTemplateTitle}</p>
+        ) : (
+          <p className="text-sm text-accent-yellow">
+            None assigned &mdash; players cannot be assessed
+          </p>
+        )}
+      </div>
+
       {/* Zone Info */}
       {group.zone && (
         <div className="mb-4">

--- a/frontend/src/components/assessments/AssessmentForm.tsx
+++ b/frontend/src/components/assessments/AssessmentForm.tsx
@@ -17,6 +17,7 @@ import { Skill, SkillCategory, SKILL_CATEGORIES } from '@/types/skills';
 import { SkillRatingInput } from './SkillRatingInput';
 import { assessmentsAPI } from '@/lib/api/assessments';
 import { skillsAPI } from '@/lib/api/skills';
+import { assessmentTemplatesAPI } from '@/lib/api';
 import { playersAPI, usersAPI, groupsAPI } from '@/lib/api';
 
 interface AssessmentFormProps {
@@ -51,6 +52,10 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
   });
 
   const [skills, setSkills] = useState<Skill[]>([]);
+  /** Title of the group's assessment, shown so the coach knows what they are scoring. */
+  const [templateTitle, setTemplateTitle] = useState<string | null>(null);
+  /** Set when the player's group has no assessment assigned, which blocks scoring. */
+  const [templateError, setTemplateError] = useState<string | null>(null);
   const [players, setPlayers] = useState<Player[]>([]);
   const [selectedPlayer, setSelectedPlayer] = useState<Player | null>(null);
   const [loading, setLoading] = useState(false);
@@ -84,11 +89,13 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
 
         // For existing assessments, load the skills and scores
         if (assessment) {
-          // Load skills for the assessment's player level
+          // Skills come from the template assigned to the player's group
           const assessmentPlayer = allPlayers.find(p => p.id === assessment.playerId);
-          if (assessmentPlayer?.level) {
-            const skillsData = await skillsAPI.getSkillsForAssessment(assessmentPlayer.level as any);
-            setSkills(skillsData);
+          if (assessmentPlayer) {
+            const template = await assessmentTemplatesAPI.getForPlayer(assessmentPlayer.id);
+            const skillsData = template.skills as any[];
+            setSkills(skillsData as any);
+            setTemplateTitle(template.title);
 
             // Load existing skill scores
             const existingScores: { [skillId: number]: SkillScoreFormData } = {};
@@ -101,7 +108,7 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
             });
 
             // Add any missing skills with zero scores
-            skillsData.forEach(skill => {
+            skillsData.forEach((skill: any) => {
               if (!existingScores[skill.id]) {
                 existingScores[skill.id] = {
                   skillId: skill.id,
@@ -133,11 +140,15 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
         const player = players.find(p => p.id === formData.playerId);
         setSelectedPlayer(player || null);
 
-        // Load skills based on player's level
-        if (player?.level) {
+        // Skills come from the template assigned to the player's group, so two
+        // players in different groups can be scored on different things.
+        if (player) {
           try {
-            const skillsForLevel = await skillsAPI.getSkillsForAssessment(player.level as any);
-            setSkills(skillsForLevel);
+            setTemplateError(null);
+            const template = await assessmentTemplatesAPI.getForPlayer(player.id);
+            const skillsForLevel = template.skills as any[];
+            setTemplateTitle(template.title);
+            setSkills(skillsForLevel as any);
 
             // Initialize skill scores for new assessments or when player changes
             if (isCreating || !assessment) {
@@ -193,8 +204,15 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
               }
             }
           } catch (err) {
-            console.error('Failed to load skills for player level:', err);
-            setError('Failed to load skills for selected player');
+            // The usual cause is a group with no assessment assigned, and the
+            // backend explains exactly that, so surface its message verbatim.
+            const message = err instanceof Error
+              ? err.message
+              : 'Failed to load the assessment for this player';
+            console.error('Failed to load assessment template:', err);
+            setSkills([]);
+            setTemplateTitle(null);
+            setTemplateError(message);
           }
         }
       } else if (!formData.playerId) {
@@ -450,14 +468,28 @@ export const AssessmentForm: React.FC<AssessmentFormProps> = ({
             <div className="p-2 bg-accent-teal/10 rounded-lg">
               <FileText className="w-5 h-5 text-accent-teal" />
             </div>
-            <h3 className="text-xl font-semibold text-text-primary">Skill Ratings</h3>
+            <div>
+              <h3 className="text-xl font-semibold text-text-primary">Skill Ratings</h3>
+              {templateTitle && (
+                <p className="text-sm text-text-secondary">
+                  From &ldquo;{templateTitle}&rdquo;, the assessment assigned to this player&apos;s group
+                </p>
+              )}
+            </div>
           </div>
 
           {!formData.playerId ? (
             <div className="text-center py-16 bg-gray-50 rounded-xl">
               <User className="mx-auto h-16 w-16 text-gray-400 mb-4" />
               <p className="text-text-primary text-lg font-medium mb-2">Select a player to load skills</p>
-              <p className="text-text-secondary">Skills will be loaded based on the player's level</p>
+              <p className="text-text-secondary">Skills come from the assessment assigned to their group</p>
+            </div>
+          ) : templateError ? (
+            <div className="text-center py-12 px-6 bg-yellow-500/10 border border-yellow-500/20 rounded-xl">
+              <p className="text-text-primary text-lg font-medium mb-2">
+                This player cannot be assessed yet
+              </p>
+              <p className="text-accent-yellow">{templateError}</p>
             </div>
           ) : skills.length === 0 ? (
             <div className="text-center py-12">

--- a/frontend/src/components/assessments/AssessmentTemplateForm.tsx
+++ b/frontend/src/components/assessments/AssessmentTemplateForm.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { Fragment, useState, useEffect, useMemo } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { AssessmentTemplate, AssessmentTemplateRequest } from '@/types/assessmentTemplates';
+import { Skill, SkillCategory, SkillLevel } from '@/types/skills';
+import { assessmentTemplatesAPI } from '@/lib/api';
+import { skillsAPI } from '@/lib/api/skills';
+
+interface AssessmentTemplateFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onComplete: (template: AssessmentTemplate) => void;
+  /** Null creates a new template; otherwise the one being edited. */
+  template?: AssessmentTemplate | null;
+}
+
+const CATEGORY_ORDER: SkillCategory[] = [
+  SkillCategory.ATHLETIC,
+  SkillCategory.TECHNICAL,
+  SkillCategory.MENTALITY,
+  SkillCategory.PERSONALITY,
+];
+
+const CATEGORY_LABELS: Record<SkillCategory, string> = {
+  [SkillCategory.ATHLETIC]: 'Athletic',
+  [SkillCategory.TECHNICAL]: 'Technical',
+  [SkillCategory.MENTALITY]: 'Mentality',
+  [SkillCategory.PERSONALITY]: 'Personality',
+};
+
+export default function AssessmentTemplateForm({
+  isOpen,
+  onClose,
+  onComplete,
+  template = null,
+}: AssessmentTemplateFormProps) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [selectedSkillIds, setSelectedSkillIds] = useState<number[]>([]);
+  const [allSkills, setAllSkills] = useState<Skill[]>([]);
+  const [levelFilter, setLevelFilter] = useState<SkillLevel | 'ALL'>('ALL');
+
+  const [isLoadingSkills, setIsLoadingSkills] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditing = template !== null;
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setTitle(template?.title ?? '');
+    setDescription(template?.description ?? '');
+    setSelectedSkillIds(template?.skills.map(s => s.id) ?? []);
+    setLevelFilter('ALL');
+    setError(null);
+
+    let cancelled = false;
+    setIsLoadingSkills(true);
+    skillsAPI
+      .getAllList()
+      .then(skills => {
+        if (cancelled) return;
+        // Inactive skills cannot be assessed, so they are not offered. One
+        // already on an edited template still shows, to explain the count.
+        const chosen = new Set(template?.skills.map(s => s.id) ?? []);
+        setAllSkills(skills.filter(s => s.isActive || chosen.has(s.id)));
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load the skills library');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingSkills(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, template]);
+
+  // Level is only a filter here. A template's skills are whatever the admin
+  // picks; the group decides who it applies to.
+  const visibleSkills = useMemo(() => {
+    if (levelFilter === 'ALL') return allSkills;
+    return allSkills.filter(s => s.applicableLevels.includes(levelFilter));
+  }, [allSkills, levelFilter]);
+
+  const skillsByCategory = useMemo(() => {
+    const grouped = new Map<SkillCategory, Skill[]>();
+    for (const category of CATEGORY_ORDER) {
+      const inCategory = visibleSkills
+        .filter(s => s.category === category)
+        .sort((a, b) => (a.displayOrder ?? 0) - (b.displayOrder ?? 0) || a.name.localeCompare(b.name));
+      if (inCategory.length > 0) grouped.set(category, inCategory);
+    }
+    return grouped;
+  }, [visibleSkills]);
+
+  const toggleSkill = (skillId: number) => {
+    setSelectedSkillIds(prev =>
+      prev.includes(skillId) ? prev.filter(id => id !== skillId) : [...prev, skillId]
+    );
+  };
+
+  const toggleCategory = (category: SkillCategory) => {
+    const ids = (skillsByCategory.get(category) ?? []).map(s => s.id);
+    const allChosen = ids.every(id => selectedSkillIds.includes(id));
+    setSelectedSkillIds(prev =>
+      allChosen ? prev.filter(id => !ids.includes(id)) : [...new Set([...prev, ...ids])]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim()) {
+      setError('Give the assessment a title.');
+      return;
+    }
+    if (selectedSkillIds.length === 0) {
+      setError('Pick at least one skill. A template with none would block every assessment for its groups.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    const payload: AssessmentTemplateRequest = {
+      title: title.trim(),
+      description: description.trim() || undefined,
+      skillIds: selectedSkillIds,
+      isActive: template?.isActive ?? true,
+    };
+
+    try {
+      const saved = isEditing
+        ? await assessmentTemplatesAPI.update(template!.id, payload)
+        : await assessmentTemplatesAPI.create(payload);
+      onComplete(saved);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save the assessment');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    'w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary';
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-3xl transform overflow-hidden rounded-2xl bg-background-modal border border-border p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title as="h3" className="text-lg font-medium text-text-primary mb-1">
+                  {isEditing ? `Edit "${template!.title}"` : 'New Assessment'}
+                </Dialog.Title>
+                <p className="text-xs text-text-secondary mb-4">
+                  Pick the skills this assessment covers. Assign it to a group to decide which
+                  players it applies to.
+                </p>
+
+                {isEditing && template!.assignedGroupCount > 0 && (
+                  <div className="mb-4 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+                    <p className="text-sm text-accent-yellow">
+                      In use by {template!.assignedGroupCount} group
+                      {template!.assignedGroupCount > 1 ? 's' : ''}:{' '}
+                      {template!.assignedGroupNames.join(', ')}. Changes apply to future
+                      assessments; those already recorded keep the skills they were scored on.
+                    </p>
+                  </div>
+                )}
+
+                {error && (
+                  <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                    <p className="text-sm text-accent-red">{error}</p>
+                  </div>
+                )}
+
+                <form onSubmit={handleSubmit} className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-1">
+                      Title *
+                    </label>
+                    <input
+                      type="text"
+                      value={title}
+                      onChange={e => setTitle(e.target.value)}
+                      className={inputClass}
+                      placeholder="e.g. Monthly Development Assessment"
+                    />
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-text-secondary mb-1">
+                      Description
+                    </label>
+                    <textarea
+                      value={description}
+                      onChange={e => setDescription(e.target.value)}
+                      rows={2}
+                      className={inputClass}
+                      placeholder="Optional note about when this assessment is used"
+                    />
+                  </div>
+
+                  <div className="border-t border-border pt-4">
+                    <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                      <span className="text-sm font-semibold text-text-primary uppercase tracking-wider">
+                        Skills ({selectedSkillIds.length} selected)
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-text-secondary">Filter by level:</span>
+                        {(['ALL', SkillLevel.DEVELOPMENT, SkillLevel.ADVANCED] as const).map(value => (
+                          <button
+                            key={value}
+                            type="button"
+                            onClick={() => setLevelFilter(value)}
+                            className={`px-2 py-1 text-xs rounded transition-colors ${
+                              levelFilter === value
+                                ? 'bg-primary text-white'
+                                : 'bg-secondary-100 text-text-secondary border border-border hover:bg-secondary-50'
+                            }`}
+                          >
+                            {value === 'ALL' ? 'All' : value === SkillLevel.DEVELOPMENT ? 'Development' : 'Advanced'}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+
+                    {isLoadingSkills ? (
+                      <div className="flex items-center justify-center py-8">
+                        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-cyan-400"></div>
+                        <span className="ml-2 text-sm text-text-secondary">Loading skills...</span>
+                      </div>
+                    ) : skillsByCategory.size === 0 ? (
+                      <p className="text-sm text-text-secondary text-center py-8">
+                        No skills match this filter.
+                      </p>
+                    ) : (
+                      <div className="space-y-4 max-h-96 overflow-y-auto pr-1">
+                        {CATEGORY_ORDER.filter(c => skillsByCategory.has(c)).map(category => {
+                          const skills = skillsByCategory.get(category)!;
+                          const allChosen = skills.every(s => selectedSkillIds.includes(s.id));
+                          return (
+                            <div key={category} className="rounded-lg border border-border p-3">
+                              <div className="flex items-center justify-between mb-2">
+                                <span className="text-sm font-medium text-text-primary">
+                                  {CATEGORY_LABELS[category]}
+                                  <span className="text-text-secondary ml-2 text-xs">
+                                    {skills.filter(s => selectedSkillIds.includes(s.id)).length}/{skills.length}
+                                  </span>
+                                </span>
+                                <button
+                                  type="button"
+                                  onClick={() => toggleCategory(category)}
+                                  className="text-xs text-primary hover:text-primary-hover transition-colors"
+                                >
+                                  {allChosen ? 'Clear all' : 'Select all'}
+                                </button>
+                              </div>
+                              <div className="grid grid-cols-1 sm:grid-cols-2 gap-1">
+                                {skills.map(skill => (
+                                  <label
+                                    key={skill.id}
+                                    className="flex items-start gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={selectedSkillIds.includes(skill.id)}
+                                      onChange={() => toggleSkill(skill.id)}
+                                      className="mt-0.5 h-4 w-4 rounded text-blue-600"
+                                    />
+                                    <span className="min-w-0">
+                                      <span className="block text-sm text-text-primary truncate">
+                                        {skill.name}
+                                      </span>
+                                      <span className="block text-xs text-text-secondary">
+                                        {skill.applicableLevels
+                                          .map(l => (l === SkillLevel.DEVELOPMENT ? 'Dev' : 'Adv'))
+                                          .join(' · ')}
+                                        {!skill.isActive && ' · inactive'}
+                                      </span>
+                                    </span>
+                                  </label>
+                                ))}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex gap-3 pt-4">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      className="flex-1 px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-white transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="flex-1 px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 rounded-lg text-text-primary font-medium transition-all disabled:opacity-50"
+                    >
+                      {isSubmitting ? 'Saving...' : isEditing ? 'Save Changes' : 'Create Assessment'}
+                    </button>
+                  </div>
+                </form>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/assessments/AssessmentTemplateManagement.tsx
+++ b/frontend/src/components/assessments/AssessmentTemplateManagement.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { AssessmentTemplate } from '@/types/assessmentTemplates';
+import { SkillCategory } from '@/types/skills';
+import { assessmentTemplatesAPI } from '@/lib/api';
+import AssessmentTemplateForm from './AssessmentTemplateForm';
+
+interface AssessmentTemplateManagementProps {
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+  /** Groups with no template, so the consequence is visible from here too. */
+  groupsWithoutTemplate?: string[];
+  /** Re-read groups after a change, since assignments are shown on each card. */
+  onTemplatesChanged?: () => void;
+}
+
+const CATEGORY_LABELS: Record<SkillCategory, string> = {
+  [SkillCategory.ATHLETIC]: 'Athletic',
+  [SkillCategory.TECHNICAL]: 'Technical',
+  [SkillCategory.MENTALITY]: 'Mentality',
+  [SkillCategory.PERSONALITY]: 'Personality',
+};
+
+export default function AssessmentTemplateManagement({
+  onError,
+  onSuccess,
+  groupsWithoutTemplate = [],
+  onTemplatesChanged,
+}: AssessmentTemplateManagementProps) {
+  const [templates, setTemplates] = useState<AssessmentTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [formState, setFormState] = useState<{ isOpen: boolean; template: AssessmentTemplate | null }>({
+    isOpen: false,
+    template: null,
+  });
+
+  const loadTemplates = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setTemplates(await assessmentTemplatesAPI.getAll(false));
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to load assessments');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [loadTemplates]);
+
+  const handleDelete = async (template: AssessmentTemplate) => {
+    if (!confirm(`Delete "${template.title}"? This cannot be undone.`)) return;
+    try {
+      await assessmentTemplatesAPI.delete(template.id);
+      onSuccess(`"${template.title}" deleted`);
+      await loadTemplates();
+      onTemplatesChanged?.();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to delete the assessment');
+    }
+  };
+
+  const countByCategory = (template: AssessmentTemplate) => {
+    const counts = new Map<SkillCategory, number>();
+    for (const skill of template.skills) {
+      counts.set(skill.category, (counts.get(skill.category) ?? 0) + 1);
+    }
+    return counts;
+  };
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-lg sm:text-xl font-semibold text-text-primary">Assessments</h2>
+          <p className="text-xs text-text-secondary mt-1">
+            Each assessment is a set of skills from the library. Assign one to a group and its
+            players are assessed on exactly those skills.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setFormState({ isOpen: true, template: null })}
+          className="w-full sm:w-auto px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 rounded-lg text-text-primary text-sm sm:text-base font-medium transition-all duration-200"
+        >
+          New Assessment
+        </button>
+      </div>
+
+      {groupsWithoutTemplate.length > 0 && (
+        <div className="mb-6 p-4 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
+          <p className="text-sm text-accent-yellow">
+            <span className="font-medium">
+              {groupsWithoutTemplate.length} group{groupsWithoutTemplate.length > 1 ? 's have' : ' has'} no
+              assessment assigned
+            </span>{' '}
+            — {groupsWithoutTemplate.join(', ')}. Their players cannot be assessed until one is
+            assigned from the Groups tab.
+          </p>
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-400"></div>
+        </div>
+      ) : templates.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-text-secondary">No assessments yet.</p>
+          <p className="text-xs text-text-secondary mt-1">
+            Create one to define what a group&apos;s players are scored on.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {templates.map(template => {
+            const counts = countByCategory(template);
+            return (
+              <div
+                key={template.id}
+                className={`rounded-xl border p-5 transition-colors ${
+                  template.isActive ? 'border-border bg-background' : 'border-border bg-background opacity-60'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <h3 className="text-base font-semibold text-text-primary">{template.title}</h3>
+                  {!template.isActive && (
+                    <span className="text-xs px-2 py-0.5 rounded-full bg-secondary-100 text-text-secondary border border-border">
+                      Inactive
+                    </span>
+                  )}
+                </div>
+
+                {template.description && (
+                  <p className="text-xs text-text-secondary mb-3">{template.description}</p>
+                )}
+
+                <p className="text-sm text-text-primary mb-2">
+                  {template.skillCount} skill{template.skillCount === 1 ? '' : 's'}
+                </p>
+
+                <div className="flex flex-wrap gap-1 mb-3">
+                  {Array.from(counts.entries()).map(([category, count]) => (
+                    <span
+                      key={category}
+                      className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary border border-primary/20"
+                    >
+                      {CATEGORY_LABELS[category]} {count}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="border-t border-border pt-3 mb-3">
+                  {template.assignedGroupCount > 0 ? (
+                    <p className="text-xs text-text-secondary">
+                      <span className="text-text-primary">Used by:</span>{' '}
+                      {template.assignedGroupNames.join(', ')}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-text-secondary">
+                      Not assigned to any group yet
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setFormState({ isOpen: true, template })}
+                    className="flex-1 px-3 py-1.5 text-sm bg-secondary-100 hover:bg-secondary-50 border border-border rounded-lg text-text-primary transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(template)}
+                    disabled={template.assignedGroupCount > 0}
+                    title={
+                      template.assignedGroupCount > 0
+                        ? 'Assigned to a group. Reassign those groups first.'
+                        : 'Delete this assessment'
+                    }
+                    className="px-3 py-1.5 text-sm bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-lg text-accent-red transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <AssessmentTemplateForm
+        isOpen={formState.isOpen}
+        template={formState.template}
+        onClose={() => setFormState({ isOpen: false, template: null })}
+        onComplete={saved => {
+          onSuccess(
+            formState.template ? `"${saved.title}" updated` : `"${saved.title}" created`
+          );
+          loadTemplates();
+          onTemplatesChanged?.();
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/assessments/AssessmentTemplateSelect.tsx
+++ b/frontend/src/components/assessments/AssessmentTemplateSelect.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { AssessmentTemplate } from '@/types/assessmentTemplates';
+import { assessmentTemplatesAPI } from '@/lib/api';
+
+interface AssessmentTemplateSelectProps {
+  value?: number;
+  onChange: (templateId: number | undefined) => void;
+}
+
+/**
+ * Picks the assessment a group's players are scored on.
+ *
+ * Only active templates are offered, since an inactive one cannot be assigned.
+ * Leaving it unset is allowed but blocks assessments for the group, so that is
+ * spelled out rather than left to be discovered by a coach.
+ */
+export default function AssessmentTemplateSelect({ value, onChange }: AssessmentTemplateSelectProps) {
+  const [templates, setTemplates] = useState<AssessmentTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    assessmentTemplatesAPI
+      .getAll(true)
+      .then(result => {
+        if (!cancelled) setTemplates(result);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selected = templates.find(t => t.id === value);
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-text-secondary mb-2">
+        Assessment (Optional)
+      </label>
+
+      <select
+        value={value ?? ''}
+        onChange={e => onChange(e.target.value ? Number(e.target.value) : undefined)}
+        disabled={isLoading || failed}
+        className="w-full px-4 py-3 bg-background border-2 border-border rounded-lg text-text-primary hover:border-primary focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-all disabled:opacity-50"
+      >
+        <option value="">
+          {isLoading ? 'Loading assessments...' : 'No assessment assigned'}
+        </option>
+        {templates.map(template => (
+          <option key={template.id} value={template.id}>
+            {template.title} ({template.skillCount} skill{template.skillCount === 1 ? '' : 's'})
+          </option>
+        ))}
+      </select>
+
+      {failed && (
+        <p className="text-xs text-accent-red mt-2">Failed to load assessments.</p>
+      )}
+
+      {!isLoading && !failed && templates.length === 0 && (
+        <div className="mt-2 p-3 bg-accent-yellow/10 border border-accent-yellow/30 rounded-lg">
+          <p className="text-xs text-accent-yellow">
+            No assessments exist yet. Create one on the Assessments tab, then assign it here.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !failed && templates.length > 0 && !value && (
+        <div className="mt-2 p-3 bg-accent-yellow/10 border border-accent-yellow/30 rounded-lg">
+          <p className="text-xs text-accent-yellow">
+            Without an assessment, this group&apos;s players cannot be assessed.
+          </p>
+        </div>
+      )}
+
+      {selected && (
+        <p className="text-xs text-text-secondary mt-2">
+          Players in this group will be scored on {selected.skillCount} skill
+          {selected.skillCount === 1 ? '' : 's'}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,10 @@ import {
   UserResponse,
 } from "@/types/auth";
 import { CreatePlayersRequest, CreatePlayersResponse } from "@/types/players";
+import {
+  AssessmentTemplate,
+  AssessmentTemplateRequest,
+} from "@/types/assessmentTemplates";
 import { apiClient } from "@/lib/apiClient";
 
 const API_BASE_URL =
@@ -517,6 +521,50 @@ export const playersAPI = {
 };
 
 // Groups API calls
+// Assessment templates: the named skill sets assigned to groups.
+export const assessmentTemplatesAPI = {
+  getAll: async (activeOnly = false): Promise<AssessmentTemplate[]> => {
+    return apiRequest<AssessmentTemplate[]>(
+      `/assessment-templates?activeOnly=${activeOnly}`
+    );
+  },
+
+  getById: async (id: number): Promise<AssessmentTemplate> => {
+    return apiRequest<AssessmentTemplate>(`/assessment-templates/${id}`);
+  },
+
+  // The template a player is assessed against, inherited from their group.
+  // Rejects with a message to show the coach when the group has none.
+  getForPlayer: async (playerId: number): Promise<AssessmentTemplate> => {
+    return apiRequest<AssessmentTemplate>(
+      `/assessment-templates/for-player/${playerId}`
+    );
+  },
+
+  create: async (data: AssessmentTemplateRequest): Promise<AssessmentTemplate> => {
+    return apiRequest<AssessmentTemplate>("/assessment-templates", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  },
+
+  update: async (
+    id: number,
+    data: AssessmentTemplateRequest
+  ): Promise<AssessmentTemplate> => {
+    return apiRequest<AssessmentTemplate>(`/assessment-templates/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    });
+  },
+
+  delete: async (id: number): Promise<void> => {
+    return apiRequest<void>(`/assessment-templates/${id}`, {
+      method: "DELETE",
+    });
+  },
+};
+
 export const groupsAPI = {
   getAll: async (params?: any): Promise<any> => {
     const queryParams = params ? `?${new URLSearchParams(params)}` : "";
@@ -545,6 +593,14 @@ export const groupsAPI = {
 
   delete: async (id: number): Promise<void> => {
     return apiRequest<void>(`/groups/${id}`, {
+      method: "DELETE",
+    });
+  },
+
+  // Unassign the group's assessment template. Separate from update, where a
+  // null id means "leave it alone". Blocks assessments for the whole group.
+  removeAssessmentTemplate: async (groupId: number): Promise<any> => {
+    return apiRequest<any>(`/groups/${groupId}/assessment-template`, {
       method: "DELETE",
     });
   },

--- a/frontend/src/lib/api/skills.ts
+++ b/frontend/src/lib/api/skills.ts
@@ -125,6 +125,19 @@ class SkillsAPI {
     return result;
   }
 
+  /**
+   * The whole library, unfiltered and unpaginated. Used by the assessment
+   * template picker, which must offer every skill regardless of level.
+   */
+  async getAllList(): Promise<Skill[]> {
+    const response = await fetch(`${API_BASE}/skills/list`, {
+      method: 'GET',
+      headers: await this.getAuthHeaders(),
+    });
+
+    return this.handleResponse<Skill[]>(response);
+  }
+
   async getSkillsForAssessment(playerLevel: SkillLevel): Promise<Skill[]> {
     const response = await fetch(`${API_BASE}/skills/list?level=${playerLevel}&activeOnly=true`, {
       method: 'GET',

--- a/frontend/src/types/assessmentTemplates.ts
+++ b/frontend/src/types/assessmentTemplates.ts
@@ -1,0 +1,32 @@
+// Assessment templates: a titled set of skills assigned to a group, deciding
+// what that group's players are assessed on.
+//
+// Not the same as an Assessment, which is one player's scored result. The
+// template is the blueprint; editing it never rewrites recorded assessments.
+//
+// Templates carry no age or level of their own. Both already describe the
+// group, and a template reaches players only by being assigned to one.
+
+import { Skill } from './skills';
+
+export interface AssessmentTemplate {
+  id: number;
+  title: string;
+  description?: string;
+  isActive: boolean;
+  skills: Skill[];
+  skillCount: number;
+  /** Groups using this template, so the blast radius of an edit is visible. */
+  assignedGroupNames: string[];
+  assignedGroupCount: number;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface AssessmentTemplateRequest {
+  title: string;
+  description?: string;
+  /** Skill ids in the order they should be scored. At least one required. */
+  skillIds: number[];
+  isActive?: boolean;
+}

--- a/frontend/src/types/groups.ts
+++ b/frontend/src/types/groups.ts
@@ -39,9 +39,14 @@ export interface GroupResponse {
   createdAt: string; // ISO datetime string
   updatedAt: string; // ISO datetime string
   
+  // Assessment template. Absent means this group's players cannot be
+  // assessed yet, since the template decides which skills are scored.
+  assessmentTemplateId?: number;
+  assessmentTemplateTitle?: string;
+
   // Coach information
   coach?: UserResponse;
-  
+
   // Pitch information
   pitchId?: number;
   pitchName?: string;
@@ -57,6 +62,8 @@ export interface GroupCreateRequest {
   ageGroup: AgeGroup;
   capacity: number;
   coachId?: number;
+  /** Assessment the group's players are scored on. Unset blocks assessments. */
+  assessmentTemplateId?: number;
   zone?: string;
   description?: string;
   isActive?: boolean;
@@ -66,6 +73,9 @@ export interface GroupCreateRequest {
 export interface GroupUpdateRequest {
   name?: string;
   capacity?: number;
+  /** Assessment the group's players are scored on. Null means "leave as is";
+   *  removing it goes through groupsAPI.removeAssessmentTemplate. */
+  assessmentTemplateId?: number;
   zone?: string;
   description?: string;
   isActive?: boolean;


### PR DESCRIPTION
Which skills a player was scored on used to be derived from their level, so everyone at a level got the same list and nobody chose it. An **assessment template** is a titled set of skills picked from the library and assigned to a group; its players are then assessed on exactly those skills.

- New **Assessments** tab to create templates and see which groups use each one
- Groups take a template when **created or edited**, and their card shows it
- A player **inherits** the template from their group — nothing is set per player

## Rules

**The template is the complete list.** Scoring a skill outside it is rejected.

**No template means no assessment.** A player whose group has none, or who has no group, cannot be assessed, and the error names the group and says how to fix it. Deliberate: falling back to every skill for the level would silently produce an assessment nobody chose the contents of.

**Templates carry no age or level.** Both already describe the group, and a template reaches players only by being assigned to one.

**Editing a template never rewrites recorded assessments.** The template is the blueprint; an assessment is the filled-in result. A template in use cannot be deleted or deactivated, and the error names the groups holding it.

## ⚠️ On deploy, every group needs a template before anyone can be assessed

Production's groups have none, so assessments are blocked until an admin assigns one to each. Nothing that was working stops working — production has zero assessments — but this is a required setup step, not a surprise. Groups missing one are flagged on their card and listed on the Assessments tab.

## Two bugs fixed along the way

**`AssessmentController` caught every exception into a generic 500 with no logging.** The reason an assessment was refused never reached the coach, and left no trace to diagnose — it cost real time finding this. Validation failures now return 400 with their message, and the catch-alls log.

**`PasswordSetupEmailListener` threw `UnexpectedRollbackException` out of `afterCompletion`.** It ran the send inside `REQUIRES_NEW`, so a mail failure marked that transaction rollback-only and dumped a stack trace on every user creation while SMTP was down. Delivery failure is now handled inside its own transaction: the token still commits and one clear line is logged. Follow-up to the after-commit change in #49, and unrelated to assessments — happy to split it out if preferred.

## Verified against a running stack

- Template created with 4 skills across 2 categories, assigned to a group, inherited by its player
- Scoring with template skills → 201 with 4 scores
- Skill outside the template → 400, *"Skill 'Running Technique' is not part of the assessment template for Cookies A"*
- No template → 400, *"Group "Cookies A" has no assessment template assigned... Assign one by editing the group"*
- Deleting a template in use → refused, naming the group
- Duplicate title → 409; zero skills → 400
- 6/6 backend tests, 45 migrations on a fresh database, `tsc` and lint clean, production build green
- Zero `UnexpectedRollbackException` after the listener fix, one clear log line instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KSHwAZjB9qU97EFgCSh4M