### PR TITLE
Group capacity, splitting, bulk player moves, and a theme sweep

### DIFF
--- a/backend/src/main/java/com/batal/controller/GroupController.java
+++ b/backend/src/main/java/com/batal/controller/GroupController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -196,6 +197,26 @@ public class GroupController {
             error.put("message", e.getMessage());
             return ResponseEntity.badRequest().body(error);
         }
+    }
+
+    // POST /api/groups/{groupId}/split - Relieve a full group by creating a
+    // sibling and moving chosen players into it.
+    @PostMapping("/{groupId}/split")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<GroupSplitResponse> splitGroup(
+            @PathVariable Long groupId,
+            @Valid @RequestBody GroupSplitRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(groupService.splitGroup(groupId, request));
+    }
+
+    // POST /api/groups/{groupId}/players/move - Move or unassign several
+    // players at once. A null targetGroupId leaves them unassigned.
+    @PostMapping("/{groupId}/players/move")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<GroupSplitResponse> movePlayers(
+            @PathVariable Long groupId,
+            @Valid @RequestBody BulkPlayerMoveRequest request) {
+        return ResponseEntity.ok(groupService.movePlayers(groupId, request));
     }
 
     // DELETE /api/groups/{groupId}/assessment-template - Unassign the template.

--- a/backend/src/main/java/com/batal/dto/BulkPlayerMoveRequest.java
+++ b/backend/src/main/java/com/batal/dto/BulkPlayerMoveRequest.java
@@ -1,0 +1,28 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Move several players out of a group in one go.
+ *
+ * A null targetGroupId means "remove them from this group", leaving them
+ * unassigned. Anything else moves them into that group.
+ */
+public class BulkPlayerMoveRequest {
+
+    @NotEmpty(message = "Select at least one player")
+    @Size(max = 100, message = "At most 100 players can be moved at once")
+    private List<Long> playerIds;
+
+    /** Destination group, or null to leave the players unassigned. */
+    private Long targetGroupId;
+
+    public List<Long> getPlayerIds() { return playerIds; }
+    public void setPlayerIds(List<Long> playerIds) { this.playerIds = playerIds; }
+
+    public Long getTargetGroupId() { return targetGroupId; }
+    public void setTargetGroupId(Long targetGroupId) { this.targetGroupId = targetGroupId; }
+}

--- a/backend/src/main/java/com/batal/dto/GroupCreateRequest.java
+++ b/backend/src/main/java/com/batal/dto/GroupCreateRequest.java
@@ -20,7 +20,7 @@ public class GroupCreateRequest {
     private AgeGroup ageGroup;
     
     @Min(value = 5, message = "Capacity must be at least 5")
-    private Integer capacity = 15;
+    private Integer capacity = 20;
     
     private Long coachId;
 

--- a/backend/src/main/java/com/batal/dto/GroupResponse.java
+++ b/backend/src/main/java/com/batal/dto/GroupResponse.java
@@ -1,12 +1,15 @@
 package com.batal.dto;
 
 import com.batal.entity.Group;
+import com.batal.entity.Player;
 import com.batal.entity.enums.AgeGroup;
 import com.batal.entity.enums.Level;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.hibernate.Hibernate;
 
 public class GroupResponse {
     
@@ -71,9 +74,23 @@ public class GroupResponse {
                     .collect(Collectors.toList()));
         }
 
-        // Set players information - we'll need to convert players to DTOs manually
-        // For now, we'll set this to empty list and let the service layer handle player details
-        this.players = List.of();
+        // Players, when the caller fetched them. The service layer was meant to
+        // fill these in and never did, leaving every group response with an
+        // empty list - which silently emptied the card's player list and any
+        // picker built on it.
+        //
+        // Guarded on initialisation rather than always loading: list endpoints
+        // page over many groups and would otherwise trigger a query per group.
+        // Endpoints that need players use findByIdWithPlayersAndCoach.
+        if (Hibernate.isInitialized(group.getPlayers())) {
+            this.players = group.getPlayers().stream()
+                    .sorted(Comparator.comparing(Player::getFirstName, Comparator.nullsLast(String::compareTo))
+                            .thenComparing(Player::getId, Comparator.nullsLast(Long::compareTo)))
+                    .map(GroupResponse::toPlayerSummary)
+                    .collect(Collectors.toList());
+        } else {
+            this.players = List.of();
+        }
     }
     
     // Getters and Setters
@@ -228,5 +245,22 @@ public class GroupResponse {
     
     public void setPlayers(List<PlayerDTO> players) {
         this.players = players;
+    }
+
+    /**
+     * Enough of a player to list and act on from a group: identity, age and
+     * level. Deliberately not the full PlayerDTO, whose parent lookups would
+     * add queries per player.
+     */
+    private static PlayerDTO toPlayerSummary(Player player) {
+        PlayerDTO dto = new PlayerDTO();
+        dto.setId(player.getId());
+        dto.setFirstName(player.getFirstName());
+        dto.setLastName(player.getLastName());
+        dto.setDateOfBirth(player.getDateOfBirth());
+        dto.setLevel(player.getLevel());
+        dto.setBasicFoot(player.getBasicFoot());
+        dto.setIsActive(player.getIsActive());
+        return dto;
     }
 }

--- a/backend/src/main/java/com/batal/dto/GroupSplitRequest.java
+++ b/backend/src/main/java/com/batal/dto/GroupSplitRequest.java
@@ -1,0 +1,49 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Relieve a full group by splitting it.
+ *
+ * Creates a sibling group carrying the same level, age group and assessment,
+ * moves the chosen players into it, and optionally places the player who
+ * triggered the overflow in whichever group the admin picked.
+ */
+public class GroupSplitRequest {
+
+    @NotBlank(message = "New group name is required")
+    @Size(max = 100, message = "Group name must not exceed 100 characters")
+    private String newGroupName;
+
+    /**
+     * Players to move out of the original group. May be empty when the admin
+     * only wants somewhere to put the new player.
+     */
+    private List<Long> playerIdsToMove;
+
+    /** The player whose assignment hit the limit. Optional. */
+    private Long newPlayerId;
+
+    /**
+     * Where newPlayerId goes. True places them in the group just created,
+     * false leaves them in the original.
+     */
+    private Boolean newPlayerJoinsNewGroup = true;
+
+    public String getNewGroupName() { return newGroupName; }
+    public void setNewGroupName(String newGroupName) { this.newGroupName = newGroupName; }
+
+    public List<Long> getPlayerIdsToMove() { return playerIdsToMove; }
+    public void setPlayerIdsToMove(List<Long> playerIdsToMove) { this.playerIdsToMove = playerIdsToMove; }
+
+    public Long getNewPlayerId() { return newPlayerId; }
+    public void setNewPlayerId(Long newPlayerId) { this.newPlayerId = newPlayerId; }
+
+    public Boolean getNewPlayerJoinsNewGroup() { return newPlayerJoinsNewGroup; }
+    public void setNewPlayerJoinsNewGroup(Boolean newPlayerJoinsNewGroup) {
+        this.newPlayerJoinsNewGroup = newPlayerJoinsNewGroup;
+    }
+}

--- a/backend/src/main/java/com/batal/dto/GroupSplitResponse.java
+++ b/backend/src/main/java/com/batal/dto/GroupSplitResponse.java
@@ -1,0 +1,28 @@
+package com.batal.dto;
+
+/**
+ * Both sides of a split, so the caller can refresh them together.
+ */
+public class GroupSplitResponse {
+
+    private GroupResponse originalGroup;
+    private GroupResponse newGroup;
+    private Integer playersMoved;
+
+    public GroupSplitResponse() {}
+
+    public GroupSplitResponse(GroupResponse originalGroup, GroupResponse newGroup, Integer playersMoved) {
+        this.originalGroup = originalGroup;
+        this.newGroup = newGroup;
+        this.playersMoved = playersMoved;
+    }
+
+    public GroupResponse getOriginalGroup() { return originalGroup; }
+    public void setOriginalGroup(GroupResponse originalGroup) { this.originalGroup = originalGroup; }
+
+    public GroupResponse getNewGroup() { return newGroup; }
+    public void setNewGroup(GroupResponse newGroup) { this.newGroup = newGroup; }
+
+    public Integer getPlayersMoved() { return playersMoved; }
+    public void setPlayersMoved(Integer playersMoved) { this.playersMoved = playersMoved; }
+}

--- a/backend/src/main/java/com/batal/entity/Group.java
+++ b/backend/src/main/java/com/batal/entity/Group.java
@@ -48,7 +48,7 @@ public class Group {
     @NotNull
     @Min(1)
     @Column(nullable = false)
-    private Integer capacity = 15;
+    private Integer capacity = 20;
     
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coach_id")

--- a/backend/src/main/java/com/batal/repository/GroupRepository.java
+++ b/backend/src/main/java/com/batal/repository/GroupRepository.java
@@ -19,6 +19,11 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     
     List<Group> findByLevelAndAgeGroup(Level level, AgeGroup ageGroup);
     List<Group> findByCoachId(Long coachId);
+    // Players and coach for a page of groups in one query, so listing groups
+    // does not fire a query per group to show their players.
+    @Query("SELECT DISTINCT g FROM Group g LEFT JOIN FETCH g.players LEFT JOIN FETCH g.coach WHERE g.id IN :ids")
+    List<Group> findAllWithPlayersByIds(@Param("ids") List<Long> ids);
+
     @Query("SELECT g FROM Group g LEFT JOIN FETCH g.players LEFT JOIN FETCH g.coach WHERE g.id = :id")
     Optional<Group> findByIdWithPlayersAndCoach(@Param("id") Long id);
     

--- a/backend/src/main/java/com/batal/service/GroupService.java
+++ b/backend/src/main/java/com/batal/service/GroupService.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -86,7 +87,18 @@ public class GroupService {
             groups = groupRepository.findAll(pageable);
         }
 
-        return groups.map(GroupResponse::new);
+        // Reload this page's groups with their players attached, in one query.
+        // Without it every group would come back with an empty player list,
+        // which is what the cards and the split picker read.
+        List<Long> ids = groups.getContent().stream().map(Group::getId).collect(Collectors.toList());
+        if (ids.isEmpty()) {
+            return groups.map(GroupResponse::new);
+        }
+
+        Map<Long, Group> withPlayers = groupRepository.findAllWithPlayersByIds(ids).stream()
+                .collect(Collectors.toMap(Group::getId, group -> group));
+
+        return groups.map(group -> new GroupResponse(withPlayers.getOrDefault(group.getId(), group)));
     }
 
     // Get group by ID
@@ -161,6 +173,132 @@ public class GroupService {
         group.setUpdatedAt(LocalDateTime.now());
         Group savedGroup = groupRepository.save(group);
         return new GroupResponse(savedGroup);
+    }
+
+    /**
+     * Relieve a full group by splitting it in two.
+     *
+     * The new group is a sibling: same level, age group, age range and
+     * assessment, so the players moved across are assessed on exactly what
+     * they were before. The coach is deliberately not copied, because one
+     * coach usually cannot take both groups, and the card will prompt for one.
+     *
+     * All of it commits together, so a failure cannot leave a half-populated
+     * group behind.
+     */
+    public GroupSplitResponse splitGroup(Long sourceGroupId, GroupSplitRequest request) {
+        Group source = groupRepository.findByIdWithPlayersAndCoach(sourceGroupId)
+                .orElseThrow(() -> new ResourceNotFoundException("Group", sourceGroupId));
+
+        Group newGroup = new Group();
+        newGroup.setName(request.getNewGroupName().trim());
+        newGroup.setLevel(source.getLevel());
+        newGroup.setAgeGroup(source.getAgeGroup());
+        newGroup.setMinAge(source.getMinAge());
+        newGroup.setMaxAge(source.getMaxAge());
+        newGroup.setCapacity(source.getCapacity());
+        newGroup.setZone(source.getZone());
+        newGroup.setAssessmentTemplate(source.getAssessmentTemplate());
+        newGroup.setIsActive(true);
+        final Group createdGroup = groupRepository.save(newGroup);
+
+        int moved = 0;
+        if (request.getPlayerIdsToMove() != null) {
+            for (Long playerId : request.getPlayerIdsToMove()) {
+                Player player = playerRepository.findById(playerId)
+                        .orElseThrow(() -> new ResourceNotFoundException("Player", playerId));
+
+                // Guard against pulling in players from unrelated groups: this
+                // operation is about redistributing one group.
+                if (player.getGroup() == null || !player.getGroup().getId().equals(sourceGroupId)) {
+                    throw new BusinessRuleException(
+                            player.getFullName() + " is not in " + source.getName()
+                                    + " and cannot be moved by splitting it.");
+                }
+
+                // Both sides: currentPlayerCount reads the group's own
+                // collection, so setting only the owning side leaves the
+                // returned counts stale even after a re-read.
+                source.getPlayers().remove(player);
+                createdGroup.getPlayers().add(player);
+                player.setGroup(createdGroup);
+                playerRepository.save(player);
+                moved++;
+            }
+        }
+
+        // The player whose assignment hit the limit, placed wherever the admin
+        // chose. No capacity check: splitting is the deliberate response to
+        // being over, and the admin has already been told.
+        if (request.getNewPlayerId() != null) {
+            Player newPlayer = playerRepository.findById(request.getNewPlayerId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Player", request.getNewPlayerId()));
+
+            boolean joinsNew = request.getNewPlayerJoinsNewGroup() == null
+                    || request.getNewPlayerJoinsNewGroup();
+            Group target = joinsNew ? createdGroup : source;
+
+            if (newPlayer.getGroup() != null) {
+                newPlayer.getGroup().getPlayers().remove(newPlayer);
+            }
+            target.getPlayers().add(newPlayer);
+            newPlayer.setGroup(target);
+            playerRepository.save(newPlayer);
+        }
+
+        return new GroupSplitResponse(
+                new GroupResponse(source),
+                new GroupResponse(createdGroup),
+                moved);
+    }
+
+    /**
+     * Move or unassign several of a group's players at once.
+     *
+     * One transaction, so a selection either lands entirely or not at all.
+     * Capacity is not enforced: the admin picked these players deliberately,
+     * and the alternative is a bulk action that half-succeeds.
+     *
+     * @return the source group, and the destination when there was one
+     */
+    public GroupSplitResponse movePlayers(Long sourceGroupId, BulkPlayerMoveRequest request) {
+        Group source = groupRepository.findByIdWithPlayersAndCoach(sourceGroupId)
+                .orElseThrow(() -> new ResourceNotFoundException("Group", sourceGroupId));
+
+        Group target = null;
+        if (request.getTargetGroupId() != null) {
+            if (request.getTargetGroupId().equals(sourceGroupId)) {
+                throw new BusinessRuleException("Those players are already in " + source.getName() + ".");
+            }
+            target = groupRepository.findByIdWithPlayersAndCoach(request.getTargetGroupId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Group", request.getTargetGroupId()));
+        }
+
+        int moved = 0;
+        for (Long playerId : request.getPlayerIds()) {
+            Player player = playerRepository.findById(playerId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Player", playerId));
+
+            if (player.getGroup() == null || !player.getGroup().getId().equals(sourceGroupId)) {
+                throw new BusinessRuleException(
+                        player.getFullName() + " is not in " + source.getName() + ".");
+            }
+
+            // Both sides, so the counts returned here are correct without a
+            // re-read: currentPlayerCount reads the group's own collection.
+            source.getPlayers().remove(player);
+            if (target != null) {
+                target.getPlayers().add(player);
+            }
+            player.setGroup(target);
+            playerRepository.save(player);
+            moved++;
+        }
+
+        return new GroupSplitResponse(
+                new GroupResponse(source),
+                target != null ? new GroupResponse(target) : null,
+                moved);
     }
 
     // Delete group

--- a/backend/src/main/resources/db/migration/V49__Set_group_capacity_to_20.sql
+++ b/backend/src/main/resources/db/migration/V49__Set_group_capacity_to_20.sql
@@ -1,0 +1,23 @@
+-- Standard group size is 20 players, up from 15.
+--
+-- Capacity stays a per-group column rather than a system-wide constant, so a
+-- group can still be deliberately smaller or larger. This only moves the
+-- default and brings existing groups in line.
+--
+-- The limit is a prompt threshold, not a hard rule: an admin who fills a group
+-- is offered the choice of adding anyway or splitting the group, so going over
+-- is possible but never silent.
+
+-- Only groups still on the old default. A capacity someone deliberately set to
+-- something else is left alone.
+UPDATE groups
+   SET capacity = 20,
+       updated_at = CURRENT_TIMESTAMP
+ WHERE capacity = 15;
+
+ALTER TABLE groups
+    ALTER COLUMN capacity SET DEFAULT 20;
+
+COMMENT ON COLUMN groups.capacity IS
+    'Standard size is 20. Exceeded only when an admin explicitly chooses to '
+    'over-fill the group rather than split it.';

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -7,6 +7,9 @@ import UserCard from '@/components/UserCard';
 import PlayerCard from '@/components/PlayerCard';
 import { PlayerAssignmentModal, CoachAssignmentModal } from '@/components/AssignmentModals';
 import AutoAssignmentModal from '@/components/AutoAssignmentModal';
+import GroupOverCapacityModal from '@/components/GroupOverCapacityModal';
+import AssignAssessmentModal from '@/components/AssignAssessmentModal';
+import GroupPlayersModal from '@/components/GroupPlayersModal';
 import PromotionModal from '@/components/PromotionModal';
 import CreatePlayerModal from '@/components/CreatePlayerModal';
 import CreateUserModal from '@/components/CreateUserModal';
@@ -98,6 +101,23 @@ export default function AdminDashboard() {
     groupId?: number;
     selectedGroup?: GroupResponse;
   }>({ isOpen: false });
+
+  // Offered when an assignment lands on a group that is already at its limit.
+  const [overCapacityModal, setOverCapacityModal] = useState<{
+    isOpen: boolean;
+    group: GroupResponse | null;
+    player: PlayerDTO | null;
+  }>({ isOpen: false, group: null, player: null });
+
+  const [assignAssessmentModal, setAssignAssessmentModal] = useState<{
+    isOpen: boolean;
+    group: GroupResponse | null;
+  }>({ isOpen: false, group: null });
+
+  const [groupPlayersModal, setGroupPlayersModal] = useState<{
+    isOpen: boolean;
+    group: GroupResponse | null;
+  }>({ isOpen: false, group: null });
 
   const [autoAssignmentModal, setAutoAssignmentModal] = useState(false);
   const [autoAssignRefreshTrigger, setAutoAssignRefreshTrigger] = useState(0);
@@ -1019,6 +1039,14 @@ export default function AdminDashboard() {
               onRemovePlayer={handleRemovePlayer}
               onUnassignPlayer={handleRemovePlayer}
               onReassignPlayer={handleReassignPlayer}
+              onViewPlayers={(groupId) => {
+                const group = groups.find(g => g.id === groupId);
+                if (group) setGroupPlayersModal({ isOpen: true, group });
+              }}
+              onAssignAssessment={(groupId) => {
+                const group = groups.find(g => g.id === groupId);
+                if (group) setAssignAssessmentModal({ isOpen: true, group });
+              }}
               onEdit={handleEditGroup}
               onDelete={handleDeleteGroup}
               onCreateGroup={handleCreateGroup}
@@ -1340,6 +1368,46 @@ export default function AdminDashboard() {
           selectedPlayer={playerAssignmentModal.selectedPlayer}
           playerPreSelected={playerAssignmentModal.playerPreSelected}
           onAssignmentComplete={handleAssignmentComplete}
+          onGroupFull={(player, group) => {
+            setPlayerAssignmentModal({ isOpen: false });
+            setOverCapacityModal({ isOpen: true, group, player });
+          }}
+        />
+
+        <GroupPlayersModal
+          isOpen={groupPlayersModal.isOpen}
+          group={groupPlayersModal.group}
+          onClose={() => setGroupPlayersModal({ isOpen: false, group: null })}
+          onChanged={async (message) => {
+            await Promise.all([loadGroupsData(), loadPlayersData()]);
+            showSuccess(message);
+          }}
+          onError={(message) => showError(message, 'Group Players')}
+        />
+
+        <AssignAssessmentModal
+          isOpen={assignAssessmentModal.isOpen}
+          group={assignAssessmentModal.group}
+          onClose={() => setAssignAssessmentModal({ isOpen: false, group: null })}
+          onComplete={(updated, message) => {
+            setGroups(prev => prev.map(g => (g.id === updated.id ? updated : g)));
+            setAssignAssessmentModal({ isOpen: false, group: null });
+            showSuccess(message);
+          }}
+          onError={(message) => showError(message, 'Assessment Assignment')}
+        />
+
+        <GroupOverCapacityModal
+          isOpen={overCapacityModal.isOpen}
+          group={overCapacityModal.group}
+          player={overCapacityModal.player}
+          onClose={() => setOverCapacityModal({ isOpen: false, group: null, player: null })}
+          onComplete={async (message) => {
+            setOverCapacityModal({ isOpen: false, group: null, player: null });
+            await Promise.all([loadGroupsData(), loadPlayersData()]);
+            showSuccess(message);
+          }}
+          onError={(message) => showError(message, 'Group Capacity')}
         />
 
         <CoachAssignmentModal

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -251,10 +251,6 @@ body {
     @apply border-t border-border;
   }
 
-  .glass-effect {
-    @apply bg-white/10 backdrop-blur-lg border border-white/20;
-  }
-
   .elevation-1 { @apply shadow-sm; }
   .elevation-2 { @apply shadow-md; }
   .elevation-3 { @apply shadow-lg; }

--- a/frontend/src/app/manager/page.tsx
+++ b/frontend/src/app/manager/page.tsx
@@ -308,7 +308,7 @@ export default function ManagerDashboard() {
                 
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                   {/* Groups by Level */}
-                  <div className="bg-white/5 rounded-lg p-4">
+                  <div className="bg-secondary-50 rounded-lg p-4">
                     <h3 className="text-lg font-medium text-gray-900 mb-3">Groups by Level</h3>
                     <div className="space-y-3">
                       <div>
@@ -344,7 +344,7 @@ export default function ManagerDashboard() {
                   </div>
 
                   {/* Groups by Age */}
-                  <div className="bg-white/5 rounded-lg p-4">
+                  <div className="bg-secondary-50 rounded-lg p-4">
                     <h3 className="text-lg font-medium text-gray-900 mb-3">Groups by Age Category</h3>
                     <div className="grid grid-cols-2 gap-3">
                       {Object.entries(groupsByAge).map(([age, count]) => (
@@ -361,13 +361,13 @@ export default function ManagerDashboard() {
               {/* Top Performing Groups */}
               <div>
                 <h3 className="text-lg font-medium text-text-primary mb-3">Top Performing Groups</h3>
-                <div className="bg-white/5 rounded-lg">
+                <div className="bg-secondary-50 rounded-lg">
                   <div className="divide-y divide-white/10">
                     {topGroups.map((group, index) => (
                       <div key={group.id} className="p-4 flex items-center justify-between">
                         <div className="flex items-center gap-4">
                           <div className={`
-                            w-8 h-8 rounded-full flex items-center justify-center text-white font-bold
+                            w-8 h-8 rounded-full flex items-center justify-center text-text-primary font-bold
                             ${index === 0 ? 'bg-yellow-500' : index === 1 ? 'bg-gray-400' : index === 2 ? 'bg-orange-600' : 'bg-blue-500'}
                           `}>
                             {index + 1}
@@ -380,7 +380,7 @@ export default function ManagerDashboard() {
                           </div>
                         </div>
                         <div className="text-right">
-                          <p className="font-medium text-white">
+                          <p className="font-medium text-text-primary">
                             {group.currentPlayerCount}/{group.capacity} players
                           </p>
                           <p className="text-sm text-text-secondary">
@@ -412,7 +412,7 @@ export default function ManagerDashboard() {
               </div>
 
               {/* Player Growth Chart */}
-              <div className="bg-white/5 rounded-lg p-6 mb-6">
+              <div className="bg-secondary-50 rounded-lg p-6 mb-6">
                 <h3 className="text-lg font-medium text-text-primary mb-4">Player Growth Trend</h3>
                 <div className="h-64 flex items-end justify-between gap-2">
                   {playerGrowthData.labels.map((label, index) => (
@@ -434,25 +434,25 @@ export default function ManagerDashboard() {
 
               {/* Key Metrics Grid */}
               <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                <div className="bg-white/5 rounded-lg p-4">
+                <div className="bg-secondary-50 rounded-lg p-4">
                   <h4 className="text-sm font-medium text-text-secondary mb-2">Average Group Size</h4>
-                  <p className="text-2xl font-bold text-white">
+                  <p className="text-2xl font-bold text-text-primary">
                     {groups.length > 0 ? Math.round(stats.totalPlayers / groups.length) : 0}
                   </p>
                   <p className="text-xs text-text-secondary mt-1">players per group</p>
                 </div>
 
-                <div className="bg-white/5 rounded-lg p-4">
+                <div className="bg-secondary-50 rounded-lg p-4">
                   <h4 className="text-sm font-medium text-text-secondary mb-2">Coach-Player Ratio</h4>
-                  <p className="text-2xl font-bold text-white">
+                  <p className="text-2xl font-bold text-text-primary">
                     1:{stats.totalCoaches > 0 ? Math.round(stats.totalPlayers / stats.totalCoaches) : 0}
                   </p>
                   <p className="text-xs text-text-secondary mt-1">optimal ratio maintained</p>
                 </div>
 
-                <div className="bg-white/5 rounded-lg p-4">
+                <div className="bg-secondary-50 rounded-lg p-4">
                   <h4 className="text-sm font-medium text-text-secondary mb-2">Retention Rate</h4>
-                  <p className="text-2xl font-bold text-white">94%</p>
+                  <p className="text-2xl font-bold text-text-primary">94%</p>
                   <p className="text-xs text-accent-teal mt-1">+2% from last month</p>
                 </div>
               </div>
@@ -461,17 +461,17 @@ export default function ManagerDashboard() {
 
           {activeTab === 'reports' && (
             <div>
-              <h2 className="text-xl font-semibold text-white mb-6">Generate Reports</h2>
+              <h2 className="text-xl font-semibold text-text-primary mb-6">Generate Reports</h2>
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <button className="bg-white/5 hover:bg-white/10 border border-white/20 rounded-lg p-6 text-left transition-colors duration-200">
+                <button className="bg-secondary-50 hover:bg-secondary-100 border border-border rounded-lg p-6 text-left transition-colors duration-200">
                   <div className="flex items-center gap-4 mb-3">
                     <div className="p-3 bg-blue-500/20 rounded-full">
                       <svg className="w-6 h-6 text-text-primary" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clipRule="evenodd" />
                       </svg>
                     </div>
-                    <h3 className="text-lg font-medium text-white">Player Progress Report</h3>
+                    <h3 className="text-lg font-medium text-text-primary">Player Progress Report</h3>
                   </div>
                   <p className="text-sm text-text-secondary mb-2">
                     Comprehensive overview of all player development metrics
@@ -479,14 +479,14 @@ export default function ManagerDashboard() {
                   <span className="text-xs text-text-secondary">Last generated: 2 days ago</span>
                 </button>
 
-                <button className="bg-white/5 hover:bg-white/10 border border-white/20 rounded-lg p-6 text-left transition-colors duration-200">
+                <button className="bg-secondary-50 hover:bg-secondary-100 border border-border rounded-lg p-6 text-left transition-colors duration-200">
                   <div className="flex items-center gap-4 mb-3">
                     <div className="p-3 bg-purple-500/20 rounded-full">
                       <svg className="w-6 h-6 text-text-primary" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
                       </svg>
                     </div>
-                    <h3 className="text-lg font-medium text-white">Coach Performance</h3>
+                    <h3 className="text-lg font-medium text-text-primary">Coach Performance</h3>
                   </div>
                   <p className="text-sm text-text-secondary mb-2">
                     Evaluation of coach effectiveness and group management
@@ -494,14 +494,14 @@ export default function ManagerDashboard() {
                   <span className="text-xs text-text-secondary">Last generated: 1 week ago</span>
                 </button>
 
-                <button className="bg-white/5 hover:bg-white/10 border border-white/20 rounded-lg p-6 text-left transition-colors duration-200">
+                <button className="bg-secondary-50 hover:bg-secondary-100 border border-border rounded-lg p-6 text-left transition-colors duration-200">
                   <div className="flex items-center gap-4 mb-3">
                     <div className="p-3 bg-green-500/20 rounded-full">
                       <svg className="w-6 h-6 text-accent-teal" fill="currentColor" viewBox="0 0 20 20">
                         <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
                       </svg>
                     </div>
-                    <h3 className="text-lg font-medium text-white">Financial Summary</h3>
+                    <h3 className="text-lg font-medium text-text-primary">Financial Summary</h3>
                   </div>
                   <p className="text-sm text-text-secondary mb-2">
                     Revenue, expenses, and payment status overview
@@ -509,14 +509,14 @@ export default function ManagerDashboard() {
                   <span className="text-xs text-text-secondary">Last generated: 3 days ago</span>
                 </button>
 
-                <button className="bg-white/5 hover:bg-white/10 border border-white/20 rounded-lg p-6 text-left transition-colors duration-200">
+                <button className="bg-secondary-50 hover:bg-secondary-100 border border-border rounded-lg p-6 text-left transition-colors duration-200">
                   <div className="flex items-center gap-4 mb-3">
                     <div className="p-3 bg-yellow-500/20 rounded-full">
                       <svg className="w-6 h-6 text-accent-yellow" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M3 6a3 3 0 013-3h10a1 1 0 01.8 1.6L14.25 8l2.55 3.4A1 1 0 0116 13H6a1 1 0 00-1 1v3a1 1 0 11-2 0V6z" clipRule="evenodd" />
                       </svg>
                     </div>
-                    <h3 className="text-lg font-medium text-white">Academy Snapshot</h3>
+                    <h3 className="text-lg font-medium text-text-primary">Academy Snapshot</h3>
                   </div>
                   <p className="text-sm text-text-secondary mb-2">
                     Executive summary of all academy operations
@@ -529,18 +529,18 @@ export default function ManagerDashboard() {
 
           {activeTab === 'finances' && (
             <div>
-              <h2 className="text-xl font-semibold text-white mb-6">Financial Overview</h2>
+              <h2 className="text-xl font-semibold text-text-primary mb-6">Financial Overview</h2>
               
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-                <div className="lg:col-span-2 bg-white/5 rounded-lg p-6">
-                  <h3 className="text-lg font-medium text-white mb-4">Revenue Breakdown</h3>
+                <div className="lg:col-span-2 bg-secondary-50 rounded-lg p-6">
+                  <h3 className="text-lg font-medium text-text-primary mb-4">Revenue Breakdown</h3>
                   <div className="space-y-4">
                     <div>
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-sm text-text-secondary">Membership Fees</span>
-                        <span className="text-sm font-medium text-white">AED 95,000</span>
+                        <span className="text-sm font-medium text-text-primary">AED 95,000</span>
                       </div>
-                      <div className="w-full bg-white/10 rounded-full h-2">
+                      <div className="w-full bg-secondary-100 rounded-full h-2">
                         <div className="h-2 rounded-full bg-green-500" style={{ width: '76%' }} />
                       </div>
                     </div>
@@ -548,9 +548,9 @@ export default function ManagerDashboard() {
                     <div>
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-sm text-text-secondary">Training Programs</span>
-                        <span className="text-sm font-medium text-white">AED 20,000</span>
+                        <span className="text-sm font-medium text-text-primary">AED 20,000</span>
                       </div>
-                      <div className="w-full bg-white/10 rounded-full h-2">
+                      <div className="w-full bg-secondary-100 rounded-full h-2">
                         <div className="h-2 rounded-full bg-blue-500" style={{ width: '16%' }} />
                       </div>
                     </div>
@@ -558,44 +558,44 @@ export default function ManagerDashboard() {
                     <div>
                       <div className="flex items-center justify-between mb-2">
                         <span className="text-sm text-text-secondary">Equipment & Merchandise</span>
-                        <span className="text-sm font-medium text-white">AED 10,000</span>
+                        <span className="text-sm font-medium text-text-primary">AED 10,000</span>
                       </div>
-                      <div className="w-full bg-white/10 rounded-full h-2">
+                      <div className="w-full bg-secondary-100 rounded-full h-2">
                         <div className="h-2 rounded-full bg-purple-500" style={{ width: '8%' }} />
                       </div>
                     </div>
                   </div>
                   
-                  <div className="mt-6 pt-6 border-t border-white/10">
+                  <div className="mt-6 pt-6 border-t border-border">
                     <div className="flex items-center justify-between">
-                      <span className="text-lg font-medium text-white">Total Revenue</span>
-                      <span className="text-2xl font-bold text-white">AED 125,000</span>
+                      <span className="text-lg font-medium text-text-primary">Total Revenue</span>
+                      <span className="text-2xl font-bold text-text-primary">AED 125,000</span>
                     </div>
                   </div>
                 </div>
 
-                <div className="bg-white/5 rounded-lg p-6">
-                  <h3 className="text-lg font-medium text-white mb-4">Payment Status</h3>
+                <div className="bg-secondary-50 rounded-lg p-6">
+                  <h3 className="text-lg font-medium text-text-primary mb-4">Payment Status</h3>
                   <div className="space-y-3">
                     <div className="flex items-center justify-between p-3 bg-green-500/10 border border-green-500/20 rounded-lg">
                       <span className="text-sm text-accent-teal">Paid</span>
-                      <span className="text-sm font-medium text-white">165</span>
+                      <span className="text-sm font-medium text-text-primary">165</span>
                     </div>
                     <div className="flex items-center justify-between p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg">
                       <span className="text-sm text-accent-yellow">Pending</span>
-                      <span className="text-sm font-medium text-white">12</span>
+                      <span className="text-sm font-medium text-text-primary">12</span>
                     </div>
                     <div className="flex items-center justify-between p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
                       <span className="text-sm text-accent-red">Overdue</span>
-                      <span className="text-sm font-medium text-white">3</span>
+                      <span className="text-sm font-medium text-text-primary">3</span>
                     </div>
                   </div>
                 </div>
               </div>
 
               {/* Quick Actions */}
-              <div className="bg-white/5 rounded-lg p-6">
-                <h3 className="text-lg font-medium text-white mb-4">Quick Actions</h3>
+              <div className="bg-secondary-50 rounded-lg p-6">
+                <h3 className="text-lg font-medium text-text-primary mb-4">Quick Actions</h3>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                   <button className="p-3 bg-blue-500/20 hover:bg-blue-500/30 border border-blue-500/30 rounded-lg text-white text-sm font-medium transition-colors duration-200">
                     Send Payment Reminders

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -162,23 +162,23 @@ export default function RegisterPage() {
 
   if (registrationSuccess) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-900 via-blue-800 to-cyan-700 flex items-center justify-center px-4">
-        <div className="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-white/20 max-w-md w-full text-center">
+      <div className="min-h-screen bg-gradient-to-br from-background to-secondary-50 flex items-center justify-center px-4">
+        <div className="bg-background border border-border rounded-2xl shadow-lg p-8 max-w-md w-full text-center">
           <div className="w-20 h-20 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
             <svg className="w-10 h-10 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           </div>
-          <h2 className="text-2xl font-bold text-white mb-2">Registration Successful!</h2>
-          <p className="text-blue-200 mb-4">Your account has been created successfully.</p>
-          <p className="text-sm text-blue-300">Redirecting to login...</p>
+          <h2 className="text-2xl font-bold text-text-primary mb-2">Registration Successful!</h2>
+          <p className="text-text-secondary mb-4">Your account has been created successfully.</p>
+          <p className="text-sm text-text-secondary">Redirecting to login...</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-900 via-blue-800 to-cyan-700 flex items-center justify-center px-4 sm:px-6 lg:px-8 relative overflow-hidden">
+    <div className="min-h-screen bg-gradient-to-br from-background to-secondary-50 flex items-center justify-center px-4 sm:px-6 lg:px-8 relative overflow-hidden">
       {/* Animated background elements */}
       <div className="absolute inset-0 overflow-hidden">
         <div className="absolute -top-40 -right-40 w-80 h-80 bg-blue-400 rounded-full mix-blend-multiply filter blur-xl opacity-70 animate-blob"></div>
@@ -189,7 +189,7 @@ export default function RegisterPage() {
       <div className="max-w-md w-full space-y-8 relative z-10">
         {/* Header */}
         <div className="text-center">
-          <div className="mx-auto mb-6 p-4 bg-white/10 backdrop-blur-lg rounded-2xl w-fit">
+          <div className="mx-auto mb-6 p-4 bg-background border border-border rounded-2xl w-fit">
             <div className="relative w-24 h-24 mx-auto">
               <Image
                 src="/Logo.jpeg"
@@ -200,23 +200,23 @@ export default function RegisterPage() {
               />
             </div>
           </div>
-          <h2 className="text-3xl font-bold text-white mb-2">Create Account</h2>
-          <p className="text-blue-200">Join Batal Football Academy</p>
+          <h2 className="text-3xl font-bold text-text-primary mb-2">Create Account</h2>
+          <p className="text-text-secondary">Join Batal Football Academy</p>
           
           {/* Progress Steps */}
           <div className="flex items-center justify-center mt-6 space-x-4">
-            <div className={`flex items-center ${step >= 1 ? 'text-cyan-300' : 'text-gray-400'}`}>
+            <div className={`flex items-center ${step >= 1 ? 'text-primary' : 'text-text-secondary'}`}>
               <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
-                step >= 1 ? 'bg-cyan-500/30 border-2 border-cyan-400' : 'bg-gray-600/30 border-2 border-gray-500'
+                step >= 1 ? 'bg-cyan-500/30 border-2 border-cyan-400' : 'bg-secondary-100 border-2 border-gray-500'
               }`}>
                 1
               </div>
               <span className="ml-2 text-sm">Basic Info</span>
             </div>
             <div className={`w-16 h-0.5 ${step >= 2 ? 'bg-cyan-400' : 'bg-gray-500'}`}></div>
-            <div className={`flex items-center ${step >= 2 ? 'text-cyan-300' : 'text-gray-400'}`}>
+            <div className={`flex items-center ${step >= 2 ? 'text-primary' : 'text-text-secondary'}`}>
               <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
-                step >= 2 ? 'bg-cyan-500/30 border-2 border-cyan-400' : 'bg-gray-600/30 border-2 border-gray-500'
+                step >= 2 ? 'bg-cyan-500/30 border-2 border-cyan-400' : 'bg-secondary-100 border-2 border-gray-500'
               }`}>
                 2
               </div>
@@ -226,12 +226,12 @@ export default function RegisterPage() {
         </div>
 
         {/* Registration Form Container */}
-        <div className="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-8 border border-white/20">
+        <div className="bg-background border border-border rounded-2xl shadow-lg p-8">
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Error Message */}
             {error && (
-              <div className="bg-red-500/20 border border-red-500/30 rounded-xl p-4 backdrop-blur-sm">
-                <p className="text-sm text-red-200">{error}</p>
+              <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4">
+                <p className="text-sm text-accent-red">{error}</p>
               </div>
             )}
 
@@ -239,7 +239,7 @@ export default function RegisterPage() {
             {step === 1 && (
               <>
                 <div>
-                  <label htmlFor="fullName" className="block text-sm font-medium text-blue-200 mb-2">
+                  <label htmlFor="fullName" className="block text-sm font-medium text-text-secondary mb-2">
                     Full Name
                   </label>
                   <input
@@ -247,18 +247,18 @@ export default function RegisterPage() {
                     type="text"
                     value={formData.fullName}
                     onChange={(e) => setFormData({ ...formData, fullName: e.target.value })}
-                    className={`appearance-none relative block w-full px-4 py-3 bg-white/10 backdrop-blur-sm border ${
-                      validationErrors.fullName ? 'border-red-500/50' : 'border-white/20'
-                    } placeholder-blue-300 text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
+                    className={`appearance-none relative block w-full px-4 py-3 bg-background border ${
+                      validationErrors.fullName ? 'border-red-500/50' : 'border-border'
+                    } placeholder-text-secondary text-text-primary rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
                     placeholder="Enter your full name"
                   />
                   {validationErrors.fullName && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.fullName}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.fullName}</p>
                   )}
                 </div>
 
                 <div>
-                  <label htmlFor="email" className="block text-sm font-medium text-blue-200 mb-2">
+                  <label htmlFor="email" className="block text-sm font-medium text-text-secondary mb-2">
                     Email Address
                   </label>
                   <input
@@ -266,18 +266,18 @@ export default function RegisterPage() {
                     type="email"
                     value={formData.email}
                     onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                    className={`appearance-none relative block w-full px-4 py-3 bg-white/10 backdrop-blur-sm border ${
-                      validationErrors.email ? 'border-red-500/50' : 'border-white/20'
-                    } placeholder-blue-300 text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
+                    className={`appearance-none relative block w-full px-4 py-3 bg-background border ${
+                      validationErrors.email ? 'border-red-500/50' : 'border-border'
+                    } placeholder-text-secondary text-text-primary rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
                     placeholder="Enter your email"
                   />
                   {validationErrors.email && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.email}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.email}</p>
                   )}
                 </div>
 
                 <div>
-                  <label htmlFor="phoneNumber" className="block text-sm font-medium text-blue-200 mb-2">
+                  <label htmlFor="phoneNumber" className="block text-sm font-medium text-text-secondary mb-2">
                     Phone Number
                   </label>
                   <input
@@ -285,18 +285,18 @@ export default function RegisterPage() {
                     type="tel"
                     value={formData.phoneNumber}
                     onChange={(e) => setFormData({ ...formData, phoneNumber: e.target.value })}
-                    className={`appearance-none relative block w-full px-4 py-3 bg-white/10 backdrop-blur-sm border ${
-                      validationErrors.phoneNumber ? 'border-red-500/50' : 'border-white/20'
-                    } placeholder-blue-300 text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
+                    className={`appearance-none relative block w-full px-4 py-3 bg-background border ${
+                      validationErrors.phoneNumber ? 'border-red-500/50' : 'border-border'
+                    } placeholder-text-secondary text-text-primary rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
                     placeholder="+1234567890"
                   />
                   {validationErrors.phoneNumber && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.phoneNumber}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.phoneNumber}</p>
                   )}
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-blue-200 mb-2">
+                  <label className="block text-sm font-medium text-text-secondary mb-2">
                     Select Role
                   </label>
                   <div className="grid grid-cols-3 gap-2">
@@ -307,8 +307,8 @@ export default function RegisterPage() {
                         onClick={() => setFormData({ ...formData, role })}
                         className={`px-3 py-2 rounded-lg border transition-all ${
                           formData.role === role
-                            ? 'bg-cyan-500/30 border-cyan-400 text-cyan-200'
-                            : 'bg-white/5 border-white/20 text-blue-200 hover:bg-white/10'
+                            ? 'bg-cyan-500/30 border-cyan-400 text-primary'
+                            : 'bg-secondary-50 border-border text-text-secondary hover:bg-secondary-100'
                         }`}
                       >
                         {role}
@@ -331,7 +331,7 @@ export default function RegisterPage() {
             {step === 2 && (
               <>
                 <div>
-                  <label htmlFor="password" className="block text-sm font-medium text-blue-200 mb-2">
+                  <label htmlFor="password" className="block text-sm font-medium text-text-secondary mb-2">
                     Password
                   </label>
                   <input
@@ -339,21 +339,21 @@ export default function RegisterPage() {
                     type="password"
                     value={formData.password}
                     onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                    className={`appearance-none relative block w-full px-4 py-3 bg-white/10 backdrop-blur-sm border ${
-                      validationErrors.password ? 'border-red-500/50' : 'border-white/20'
-                    } placeholder-blue-300 text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
+                    className={`appearance-none relative block w-full px-4 py-3 bg-background border ${
+                      validationErrors.password ? 'border-red-500/50' : 'border-border'
+                    } placeholder-text-secondary text-text-primary rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
                     placeholder="Create a strong password"
                   />
                   {validationErrors.password && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.password}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.password}</p>
                   )}
                   
                   {/* Password Strength Indicator */}
                   {formData.password && (
                     <div className="mt-2">
                       <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs text-blue-200">Password strength</span>
-                        <span className="text-xs text-blue-300">{getPasswordStrength().text}</span>
+                        <span className="text-xs text-text-secondary">Password strength</span>
+                        <span className="text-xs text-text-secondary">{getPasswordStrength().text}</span>
                       </div>
                       <div className="h-1.5 bg-gray-600 rounded-full overflow-hidden">
                         <div 
@@ -366,7 +366,7 @@ export default function RegisterPage() {
                 </div>
 
                 <div>
-                  <label htmlFor="confirmPassword" className="block text-sm font-medium text-blue-200 mb-2">
+                  <label htmlFor="confirmPassword" className="block text-sm font-medium text-text-secondary mb-2">
                     Confirm Password
                   </label>
                   <input
@@ -374,13 +374,13 @@ export default function RegisterPage() {
                     type="password"
                     value={formData.confirmPassword}
                     onChange={(e) => setFormData({ ...formData, confirmPassword: e.target.value })}
-                    className={`appearance-none relative block w-full px-4 py-3 bg-white/10 backdrop-blur-sm border ${
-                      validationErrors.confirmPassword ? 'border-red-500/50' : 'border-white/20'
-                    } placeholder-blue-300 text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
+                    className={`appearance-none relative block w-full px-4 py-3 bg-background border ${
+                      validationErrors.confirmPassword ? 'border-red-500/50' : 'border-border'
+                    } placeholder-text-secondary text-text-primary rounded-xl focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-transparent transition-all duration-200`}
                     placeholder="Re-enter your password"
                   />
                   {validationErrors.confirmPassword && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.confirmPassword}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.confirmPassword}</p>
                   )}
                 </div>
 
@@ -390,21 +390,21 @@ export default function RegisterPage() {
                       type="checkbox"
                       checked={formData.termsAccepted}
                       onChange={(e) => setFormData({ ...formData, termsAccepted: e.target.checked })}
-                      className="h-4 w-4 text-cyan-600 focus:ring-cyan-500 border-white/30 rounded bg-white/10 backdrop-blur-sm mt-0.5"
+                      className="h-4 w-4 text-cyan-600 focus:ring-cyan-500 border-border rounded bg-background mt-0.5"
                     />
-                    <span className="ml-2 text-sm text-blue-200">
+                    <span className="ml-2 text-sm text-text-secondary">
                       I agree to the{" "}
-                      <Link href="/terms" className="text-cyan-300 hover:text-cyan-200 underline">
+                      <Link href="/terms" className="text-primary hover:text-primary underline">
                         Terms of Service
                       </Link>{" "}
                       and{" "}
-                      <Link href="/privacy" className="text-cyan-300 hover:text-cyan-200 underline">
+                      <Link href="/privacy" className="text-primary hover:text-primary underline">
                         Privacy Policy
                       </Link>
                     </span>
                   </label>
                   {validationErrors.termsAccepted && (
-                    <p className="mt-1 text-xs text-red-300">{validationErrors.termsAccepted}</p>
+                    <p className="mt-1 text-xs text-accent-red">{validationErrors.termsAccepted}</p>
                   )}
                 </div>
 
@@ -420,7 +420,7 @@ export default function RegisterPage() {
                   <button
                     type="button"
                     onClick={handleBack}
-                    className="w-full py-3 px-4 border border-white/20 rounded-xl text-sm font-medium text-blue-200 hover:bg-white/5 transition-all duration-200"
+                    className="w-full py-3 px-4 border border-border rounded-xl text-sm font-medium text-text-secondary hover:bg-secondary-50 transition-all duration-200"
                   >
                     ← Back
                   </button>
@@ -432,14 +432,14 @@ export default function RegisterPage() {
 
         {/* Links */}
         <div className="text-center space-y-2">
-          <p className="text-sm text-blue-200">
+          <p className="text-sm text-text-secondary">
             Already have an account?{" "}
-            <Link href="/login" className="font-medium text-cyan-300 hover:text-cyan-100 transition-colors duration-200 underline underline-offset-4">
+            <Link href="/login" className="font-medium text-primary hover:text-cyan-100 transition-colors duration-200 underline underline-offset-4">
               Sign in
             </Link>
           </p>
-          <p className="text-sm text-blue-200">
-            <Link href="/" className="font-medium text-cyan-300 hover:text-cyan-100 transition-colors duration-200">
+          <p className="text-sm text-text-secondary">
+            <Link href="/" className="font-medium text-primary hover:text-cyan-100 transition-colors duration-200">
               ← Back to Home
             </Link>
           </p>

--- a/frontend/src/components/AssignAssessmentModal.tsx
+++ b/frontend/src/components/AssignAssessmentModal.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { Fragment, useState, useEffect } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { GroupResponse } from '@/types/groups';
+import { groupsAPI } from '@/lib/api';
+import AssessmentTemplateSelect from '@/components/assessments/AssessmentTemplateSelect';
+
+interface AssignAssessmentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  group: GroupResponse | null;
+  onComplete: (group: GroupResponse, message: string) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * Set a group's assessment straight from its card, without opening the full
+ * edit form for a one-field change.
+ */
+export default function AssignAssessmentModal({
+  isOpen,
+  onClose,
+  group,
+  onComplete,
+  onError,
+}: AssignAssessmentModalProps) {
+  const [templateId, setTemplateId] = useState<number | undefined>(undefined);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !group) return;
+    setTemplateId(group.assessmentTemplateId);
+  }, [isOpen, group]);
+
+  const handleSave = async () => {
+    if (!group) return;
+
+    setIsSubmitting(true);
+    try {
+      let updated: GroupResponse;
+      let message: string;
+
+      if (templateId === undefined) {
+        // A null id means "no change" to the update endpoint, so clearing has
+        // its own call.
+        updated = await groupsAPI.removeAssessmentTemplate(group.id);
+        message = `${group.name} has no assessment now, so its players cannot be assessed`;
+      } else {
+        updated = await groupsAPI.update(group.id, { assessmentTemplateId: templateId });
+        message = `Assessment assigned to ${group.name}`;
+      }
+
+      onComplete(updated, message);
+      onClose();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : 'Failed to assign the assessment');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!group) return null;
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-md transform overflow-visible rounded-2xl bg-background-modal border border-border p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title as="h3" className="text-lg font-medium text-text-primary mb-1">
+                  Assessment for {group.name}
+                </Dialog.Title>
+                <p className="text-xs text-text-secondary mb-4">
+                  Decides which skills this group&apos;s players are scored on.
+                </p>
+
+                <AssessmentTemplateSelect value={templateId} onChange={setTemplateId} />
+
+                <div className="flex gap-3 pt-6">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    disabled={isSubmitting}
+                    className="flex-1 px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-white transition-colors disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={isSubmitting}
+                    className="flex-1 px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 rounded-lg text-text-primary font-medium transition-all disabled:opacity-50"
+                  >
+                    {isSubmitting ? 'Saving...' : 'Save'}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/AssignmentModals.tsx
+++ b/frontend/src/components/AssignmentModals.tsx
@@ -28,6 +28,11 @@ interface PlayerAssignmentModalProps {
   selectedPlayer?: PlayerDTO;
   playerPreSelected?: boolean;
   onAssignmentComplete?: (playerId: number, groupId: number) => void;
+  /**
+   * The group is already at its limit. The parent decides what to offer, since
+   * exceeding the limit is a deliberate choice rather than an error.
+   */
+  onGroupFull?: (player: PlayerDTO, group: GroupResponse) => void;
 }
 
 export function PlayerAssignmentModal({ 
@@ -37,7 +42,8 @@ export function PlayerAssignmentModal({
   selectedGroup,
   selectedPlayer: preSelectedPlayer,
   playerPreSelected = false,
-  onAssignmentComplete 
+  onAssignmentComplete,
+  onGroupFull
 }: PlayerAssignmentModalProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -156,6 +162,15 @@ export function PlayerAssignmentModal({
     } catch (err) {
       console.error('Player assignment failed:', err);
       const errorMessage = err instanceof Error ? err.message : 'Assignment failed';
+
+      // A full group is not a dead end: hand back to the parent, which offers
+      // adding anyway or splitting the group.
+      if (/full capacity/i.test(errorMessage) && onGroupFull) {
+        onGroupFull(selectedPlayer, selectedGroup_);
+        handleClose();
+        return;
+      }
+
       setError(errorMessage);
     } finally {
       setLoading(false);
@@ -201,7 +216,7 @@ export function PlayerAssignmentModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-25 backdrop-blur-sm" />
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -215,7 +230,7 @@ export function PlayerAssignmentModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-visible bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-visible bg-background-modal border border-border rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
                 <Dialog.Title className="text-lg font-medium text-text-primary mb-4">
                   Assign Player to Group
                 </Dialog.Title>
@@ -252,7 +267,7 @@ export function PlayerAssignmentModal({
                         onChange={setSelectedPlayer}
                       >
                         <div className="relative">
-                          <Listbox.Button className="w-full px-3 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400 flex items-center justify-between">
+                          <Listbox.Button className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400 flex items-center justify-between">
                             <span>
                               {selectedPlayer 
                                 ? `${selectedPlayer.firstName} ${selectedPlayer.lastName}${selectedPlayer.level ? ` - ${selectedPlayer.level}` : ''}` 
@@ -262,7 +277,7 @@ export function PlayerAssignmentModal({
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                             </svg>
                           </Listbox.Button>
-                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-auto">
+                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border rounded-lg shadow-lg max-h-40 overflow-auto">
                             {unassignedPlayers.length === 0 ? (
                               <div className="px-3 py-2 text-text-secondary text-sm">
                                 No unassigned players available
@@ -292,10 +307,10 @@ export function PlayerAssignmentModal({
                       </label>
                       <Listbox value={selectedGroup_} onChange={setSelectedGroup_}>
                         <div className="relative">
-                          <Listbox.Button className="w-full px-3 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
+                          <Listbox.Button className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
                             {selectedGroup_ ? selectedGroup_.name : 'Choose a group...'}
                           </Listbox.Button>
-                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-auto">
+                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border rounded-lg shadow-lg max-h-40 overflow-auto">
                             {availableGroups.map((group) => (
                               <Listbox.Option
                                 key={group.id}
@@ -542,7 +557,7 @@ export function CoachAssignmentModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-25 backdrop-blur-sm" />
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -556,7 +571,7 @@ export function CoachAssignmentModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-background-modal border border-border rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
                 <Dialog.Title className="text-lg font-medium text-text-primary mb-4">
                   Assign Coach to Group
                 </Dialog.Title>
@@ -581,10 +596,10 @@ export function CoachAssignmentModal({
                       }}
                     >
                       <div className="relative">
-                        <Listbox.Button className="w-full px-3 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
+                        <Listbox.Button className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
                           {selectedCoach ? selectedCoach.firstName + ' ' + selectedCoach.lastName : 'Choose a coach...'}
                         </Listbox.Button>
-                        <Listbox.Options className="absolute z-10 mt-1 w-full bg-background-modal border border-border border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-auto">
+                        <Listbox.Options className="absolute z-10 mt-1 w-full bg-background-modal border border-border rounded-lg shadow-lg max-h-40 overflow-auto">
                           {availableCoaches.map((coach) => (
                             <Listbox.Option
                               key={coach.id}
@@ -607,10 +622,10 @@ export function CoachAssignmentModal({
                       </label>
                       <Listbox value={selectedGroup_} onChange={setSelectedGroup_}>
                         <div className="relative">
-                          <Listbox.Button className="w-full px-3 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
+                          <Listbox.Button className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400">
                             {selectedGroup_ ? selectedGroup_.name : 'Choose a group...'}
                           </Listbox.Button>
-                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-auto">
+                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border rounded-lg shadow-lg max-h-40 overflow-auto">
                             {availableGroups.map((group) => (
                               <Listbox.Option
                                 key={group.id}

--- a/frontend/src/components/AutoAssignmentModal.tsx
+++ b/frontend/src/components/AutoAssignmentModal.tsx
@@ -175,8 +175,8 @@ export default function AutoAssignmentModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-3xl transform overflow-hidden rounded-2xl bg-gray-800 p-6 text-left align-middle shadow-xl transition-all">
-                <Dialog.Title as="h3" className="text-lg font-medium text-white mb-4">
+              <Dialog.Panel className="w-full max-w-3xl transform overflow-hidden rounded-2xl bg-background-modal p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title as="h3" className="text-lg font-medium text-text-primary mb-4">
                   Auto-Assign Unassigned Players
                 </Dialog.Title>
 
@@ -221,7 +221,7 @@ export default function AutoAssignmentModal({
                             className={`p-3 rounded-lg border transition-all cursor-pointer ${
                               selectedPlayers.has(player.id!)
                                 ? 'bg-blue-500/20 border-blue-500/40'
-                                : 'bg-gray-700/50 border-gray-600/50 hover:bg-gray-700/70'
+                                : 'bg-secondary-50 border-border hover:bg-secondary-100'
                             }`}
                             onClick={() => togglePlayerSelection(player.id!)}
                           >
@@ -235,10 +235,10 @@ export default function AutoAssignmentModal({
                                 />
                                 <div>
                                   <div className="flex items-center space-x-2">
-                                    <span className="text-white font-medium">
+                                    <span className="text-text-primary font-medium">
                                       {player.firstName} {player.lastName}
                                     </span>
-                                    <span className={`px-2 py-0.5 text-xs rounded-full text-white ${getAgeGroupColor(player)}`}>
+                                    <span className={`px-2 py-0.5 text-xs rounded-full text-text-primary ${getAgeGroupColor(player)}`}>
                                       {player.dateOfBirth && AssignmentService.getAgeGroup(player.dateOfBirth)}
                                     </span>
                                     <span className="px-2 py-0.5 text-xs bg-purple-500 rounded-full text-white">
@@ -281,7 +281,7 @@ export default function AutoAssignmentModal({
                       <div className="flex gap-3">
                         <button
                           onClick={handleClose}
-                          className="px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-white transition-colors"
+                          className="px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-text-primary transition-colors"
                         >
                           Cancel
                         </button>
@@ -326,7 +326,7 @@ export default function AutoAssignmentModal({
                     <div className="flex justify-end">
                       <button
                         onClick={handleClose}
-                        className="px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-white transition-colors"
+                        className="px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-text-primary transition-colors"
                       >
                         Close
                       </button>

--- a/frontend/src/components/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/DeleteConfirmationModal.tsx
@@ -56,7 +56,7 @@ export default function DeleteConfirmationModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-gray-800 border border-gray-700 rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden bg-background-modal border border-gray-700 rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
                 {/* Warning Icon */}
                 <div className="flex items-center justify-center w-12 h-12 bg-red-500/20 rounded-full mx-auto mb-4">
                   <svg
@@ -74,7 +74,7 @@ export default function DeleteConfirmationModal({
                   </svg>
                 </div>
 
-                <Dialog.Title className="text-lg font-semibold text-white text-center mb-2">
+                <Dialog.Title className="text-lg font-semibold text-text-primary text-center mb-2">
                   {title}
                 </Dialog.Title>
 
@@ -83,7 +83,7 @@ export default function DeleteConfirmationModal({
                     {message}
                   </p>
                   {itemName && (
-                    <p className="text-sm font-medium text-white bg-gray-700/50 px-3 py-2 rounded-lg">
+                    <p className="text-sm font-medium text-text-primary bg-secondary-100 px-3 py-2 rounded-lg">
                       "{itemName}"
                     </p>
                   )}

--- a/frontend/src/components/ErrorNotification.tsx
+++ b/frontend/src/components/ErrorNotification.tsx
@@ -92,14 +92,14 @@ export default function ErrorNotification({
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <div className={`${colors.bg} backdrop-blur-lg ${colors.border} border rounded-2xl shadow-2xl p-4`}>
+        <div className={`${colors.bg} ${colors.border} border rounded-2xl shadow-2xl p-4`}>
           <div className="flex">
             <div className="flex-shrink-0">
               {getIcon()}
             </div>
             <div className="ml-3 w-0 flex-1 pt-0.5">
               {title && (
-                <p className="text-sm font-medium text-white">
+                <p className={`text-sm font-medium ${colors.text}`}>
                   {title}
                 </p>
               )}
@@ -120,9 +120,9 @@ export default function ErrorNotification({
           </div>
           {autoClose && (
             <div className="mt-3">
-              <div className={`h-1 ${colors.bg} rounded-full overflow-hidden`}>
+              <div className="h-1 bg-black/10 rounded-full overflow-hidden">
                 <div 
-                  className="h-full bg-white/30 rounded-full animate-shrink"
+                  className="h-full bg-black/25 rounded-full animate-shrink"
                   style={{ animationDuration: `${autoCloseDelay}ms` }}
                 />
               </div>

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -4,8 +4,6 @@ import { useState } from 'react';
 import { GroupResponse, AGE_GROUP_METADATA } from '@/types/groups';
 import { Level } from '@/types/players';
 import { PlayerDTO } from '@/types/players';
-import UnassignPlayerModal from './UnassignPlayerModal';
-import ReassignPlayerModal from './ReassignPlayerModal';
 
 interface GroupCardProps {
   group: GroupResponse;
@@ -13,11 +11,12 @@ interface GroupCardProps {
   onAssignPlayer?: (groupId: number) => void;
   onRemoveCoach?: (groupId: number) => void;
   onRemovePlayer?: (groupId: number, playerId: number) => void;
-  onUnassignPlayer?: (groupId: number, playerId: number) => void;
-  onReassignPlayer?: (playerId: number, fromGroupId: number, toGroupId: number) => void;
   onViewDetails?: (groupId: number) => void;
   onEdit?: (groupId: number) => void;
   onDelete?: (groupId: number) => void;
+  onAssignAssessment?: (groupId: number) => void;
+  /** Opens the dialog listing this group's players, with bulk actions. */
+  onViewPlayers?: (groupId: number) => void;
   onActivate?: (groupId: number) => void;
   onDeactivate?: (groupId: number) => void;
   showActions?: boolean;
@@ -26,17 +25,21 @@ interface GroupCardProps {
   onSelect?: (groupId: number) => void;
 }
 
+// The three primary card actions share a width so they line up, since their
+// labels differ in length and btn-xs alone only matches padding.
+const CARD_ACTION_CLASS = 'btn-xs w-32 justify-center';
+
 export default function GroupCard({ 
   group, 
   onAssignCoach,
   onAssignPlayer,
   onRemoveCoach,
   onRemovePlayer,
-  onUnassignPlayer,
-  onReassignPlayer, 
   onViewDetails, 
   onEdit,
   onDelete,
+  onAssignAssessment,
+  onViewPlayers,
   onActivate,
   onDeactivate,
   showActions = true,
@@ -45,21 +48,6 @@ export default function GroupCard({
   onSelect
 }: GroupCardProps) {
   const [isHovered, setIsHovered] = useState(false);
-  const [unassignModal, setUnassignModal] = useState<{
-    isOpen: boolean;
-    player: PlayerDTO | null;
-  }>({
-    isOpen: false,
-    player: null
-  });
-  
-  const [reassignModal, setReassignModal] = useState<{
-    isOpen: boolean;
-    player: PlayerDTO | null;
-  }>({
-    isOpen: false,
-    player: null
-  });
   
   const ageGroupMeta = AGE_GROUP_METADATA[group.ageGroup];
   const utilizationPercentage = Math.round((group.currentPlayerCount / group.capacity) * 100);
@@ -74,42 +62,6 @@ export default function GroupCard({
     if (percentage >= 90) return 'text-accent-red';
     if (percentage >= 75) return 'text-accent-yellow';
     return 'text-accent-teal';
-  };
-
-  const handleUnassignClick = (player: PlayerDTO) => {
-    setUnassignModal({
-      isOpen: true,
-      player: player
-    });
-  };
-
-  const handleUnassignConfirm = () => {
-    if (unassignModal.player && unassignModal.player.id && onUnassignPlayer) {
-      onUnassignPlayer(group.id, unassignModal.player.id);
-    }
-    setUnassignModal({ isOpen: false, player: null });
-  };
-
-  const handleUnassignClose = () => {
-    setUnassignModal({ isOpen: false, player: null });
-  };
-
-  const handleReassignClick = (player: PlayerDTO) => {
-    setReassignModal({
-      isOpen: true,
-      player: player
-    });
-  };
-
-  const handleReassignConfirm = (newGroupId: number) => {
-    if (reassignModal.player && reassignModal.player.id && onReassignPlayer) {
-      onReassignPlayer(reassignModal.player.id, group.id, newGroupId);
-    }
-    setReassignModal({ isOpen: false, player: null });
-  };
-
-  const handleReassignClose = () => {
-    setReassignModal({ isOpen: false, player: null });
   };
 
   const handleClick = () => {
@@ -235,7 +187,7 @@ export default function GroupCard({
                   e.stopPropagation();
                   onAssignCoach(group.id);
                 }}
-                className="btn-secondary btn-xs"
+                className={`btn-secondary ${CARD_ACTION_CLASS}`}
               >
                 Assign Coach
               </button>
@@ -254,11 +206,37 @@ export default function GroupCard({
           <span className="text-sm font-medium">Assessment</span>
         </div>
         {group.assessmentTemplateTitle ? (
-          <p className="text-sm text-text-primary">{group.assessmentTemplateTitle}</p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm text-text-primary truncate">{group.assessmentTemplateTitle}</p>
+            {showActions && onAssignAssessment && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAssignAssessment(group.id);
+                }}
+                className={`btn-secondary ${CARD_ACTION_CLASS} flex-shrink-0`}
+              >
+                Change
+              </button>
+            )}
+          </div>
         ) : (
-          <p className="text-sm text-accent-yellow">
-            None assigned &mdash; players cannot be assessed
-          </p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm text-accent-yellow">
+              None &mdash; players cannot be assessed
+            </p>
+            {showActions && onAssignAssessment && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAssignAssessment(group.id);
+                }}
+                className={`btn-secondary ${CARD_ACTION_CLASS} flex-shrink-0`}
+              >
+                Assign Assessment
+              </button>
+            )}
+          </div>
         )}
       </div>
 
@@ -284,7 +262,7 @@ export default function GroupCard({
             </svg>
             <span className="text-sm font-medium">Players</span>
           </div>
-          {showActions && onAssignPlayer && !group.isFull && (
+          {showActions && onAssignPlayer && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -295,7 +273,7 @@ export default function GroupCard({
                   console.error('onAssignPlayer is not defined');
                 }
               }}
-              className="btn-success btn-xs"
+              className={`btn-success ${CARD_ACTION_CLASS}`}
             >
               Add Player
             </button>
@@ -305,49 +283,29 @@ export default function GroupCard({
           {group.currentPlayerCount} / {group.capacity} players
         </p>
         
-        {/* Players List */}
-        {group.players && group.players.length > 0 && (
-          <div className="space-y-1 max-h-32 overflow-y-auto">
-            {group.players.map((player) => (
-              <div key={player.id} className="flex items-center justify-between bg-secondary-50 rounded px-2 py-1">
-                <span className="text-xs text-text-primary">
-                  {player.firstName} {player.lastName}
-                </span>
-                {showActions && (onUnassignPlayer || onReassignPlayer) && (
-                  <div className="flex gap-1">
-                    {onReassignPlayer && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleReassignClick(player);
-                        }}
-                        className="btn-outline btn-xs"
-                        title={`Reassign ${player.firstName} ${player.lastName} to another group`}
-                      >
-                        ↗
-                      </button>
-                    )}
-                    {onUnassignPlayer && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleUnassignClick(player);
-                        }}
-                        className="btn-destructive btn-xs"
-                        title={`Remove ${player.firstName} ${player.lastName} from group`}
-                      >
-                        ×
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
+        {/* The inline list did not scale: at twenty players it filled the
+            card and buried the actions. The full list, search and bulk
+            actions live in the players dialog instead. */}
+        {showActions && onViewPlayers && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onViewPlayers(group.id);
+            }}
+            disabled={group.currentPlayerCount === 0}
+            className={`btn-secondary ${CARD_ACTION_CLASS} disabled:opacity-40 disabled:cursor-not-allowed`}
+            title={
+              group.currentPlayerCount === 0
+                ? 'No players in this group yet'
+                : 'View, move or remove this group\'s players'
+            }
+          >
+            View Players
+          </button>
         )}
-        
-        {group.players && group.players.length === 0 && (
-          <p className="text-xs text-text-secondary italic">No players assigned</p>
+
+        {group.currentPlayerCount === 0 && (
+          <p className="text-xs text-text-secondary italic mt-2">No players assigned</p>
         )}
       </div>
 
@@ -416,8 +374,7 @@ export default function GroupCard({
               title="Delete Group"
             >
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M9 2a1 1 0 000 2h2a1 1 0 100-2H9z" clipRule="evenodd" />
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8 7a1 1 0 012 0v4a1 1 0 11-2 0V7zM12 7a1 1 0 112 0v4a1 1 0 11-2 0V7z" clipRule="evenodd" />
+                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
             </button>
           )}
@@ -431,24 +388,6 @@ export default function GroupCard({
         </div>
       )}
 
-      {/* Unassign Player Modal */}
-      <UnassignPlayerModal
-        isOpen={unassignModal.isOpen}
-        onClose={handleUnassignClose}
-        onConfirm={handleUnassignConfirm}
-        player={unassignModal.player}
-        groupName={group.name}
-      />
-
-      {/* Reassign Player Modal */}
-      <ReassignPlayerModal
-        isOpen={reassignModal.isOpen}
-        onClose={handleReassignClose}
-        onConfirm={handleReassignConfirm}
-        player={reassignModal.player}
-        currentGroupId={group.id}
-        currentGroupName={group.name}
-      />
     </div>
   );
 }

--- a/frontend/src/components/GroupList.tsx
+++ b/frontend/src/components/GroupList.tsx
@@ -13,6 +13,8 @@ interface GroupListProps {
   onRemovePlayer?: (groupId: number, playerId: number) => void;
   onUnassignPlayer?: (groupId: number, playerId: number) => void;
   onReassignPlayer?: (playerId: number, fromGroupId: number, toGroupId: number) => void;
+  onAssignAssessment?: (groupId: number) => void;
+  onViewPlayers?: (groupId: number) => void;
   onViewDetails?: (groupId: number) => void;
   onEdit?: (groupId: number) => void;
   onDelete?: (groupId: number) => void;
@@ -36,6 +38,8 @@ export default function GroupList({
   onRemovePlayer,
   onUnassignPlayer,
   onReassignPlayer,
+  onAssignAssessment,
+  onViewPlayers,
   onViewDetails,
   onEdit,
   onDelete,
@@ -152,10 +156,10 @@ export default function GroupList({
       <div className="space-y-4">
         <div className="bg-background border border-border shadow-sm rounded-xl p-6">
           <div className="animate-pulse space-y-4">
-            <div className="h-4 bg-white/20 rounded w-1/4"></div>
+            <div className="h-4 bg-secondary-100 rounded w-1/4"></div>
             <div className="space-y-2">
-              <div className="h-3 bg-white/20 rounded"></div>
-              <div className="h-3 bg-white/20 rounded w-5/6"></div>
+              <div className="h-3 bg-secondary-100 rounded"></div>
+              <div className="h-3 bg-secondary-100 rounded w-5/6"></div>
             </div>
           </div>
         </div>
@@ -163,10 +167,10 @@ export default function GroupList({
           {[...Array(6)].map((_, i) => (
             <div key={i} className="bg-background border border-border shadow-sm rounded-xl p-6">
               <div className="animate-pulse space-y-4">
-                <div className="h-4 bg-white/20 rounded w-3/4"></div>
-                <div className="h-3 bg-white/20 rounded w-1/2"></div>
-                <div className="h-2 bg-white/20 rounded"></div>
-                <div className="h-8 bg-white/20 rounded"></div>
+                <div className="h-4 bg-secondary-100 rounded w-3/4"></div>
+                <div className="h-3 bg-secondary-100 rounded w-1/2"></div>
+                <div className="h-2 bg-secondary-100 rounded"></div>
+                <div className="h-8 bg-secondary-100 rounded"></div>
               </div>
             </div>
           ))}
@@ -248,7 +252,7 @@ export default function GroupList({
                 type="checkbox"
                 checked={showInactive}
                 onChange={(e) => setShowInactive(e.target.checked)}
-                className="mr-2 h-4 w-4 text-cyan-600 focus:ring-cyan-500 border-white/30 rounded bg-white/10"
+                className="mr-2 h-4 w-4 text-cyan-600 focus:ring-cyan-500 border-border rounded bg-secondary-100"
               />
               Show Inactive
             </label>
@@ -258,7 +262,7 @@ export default function GroupList({
           <div>
             <button
               onClick={clearFilters}
-              className="w-full px-3 py-2 bg-white/10 hover:bg-white/20 border border-white/20 rounded-lg text-text-primary text-sm transition-colors duration-200"
+              className="w-full px-3 py-2 bg-secondary-100 hover:bg-secondary-50 border border-border rounded-lg text-text-primary text-sm transition-colors duration-200"
             >
               Clear Filters
             </button>
@@ -282,7 +286,7 @@ export default function GroupList({
             <div className="mt-6">
               <button
                 onClick={onCreateGroup}
-                className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700 rounded-xl text-text-primary font-medium transition-all duration-200"
+                className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700 rounded-xl text-white font-medium transition-all duration-200"
               >
                 <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
@@ -310,8 +314,8 @@ export default function GroupList({
                     onAssignPlayer={onAssignPlayer}
                     onRemoveCoach={onRemoveCoach}
                     onRemovePlayer={onRemovePlayer}
-                    onUnassignPlayer={onUnassignPlayer}
-                    onReassignPlayer={onReassignPlayer}
+                    onAssignAssessment={onAssignAssessment}
+                    onViewPlayers={onViewPlayers}
                     onViewDetails={onViewDetails}
                     onEdit={onEdit}
                     onDelete={onDelete}
@@ -343,8 +347,8 @@ export default function GroupList({
                     onAssignPlayer={onAssignPlayer}
                     onRemoveCoach={onRemoveCoach}
                     onRemovePlayer={onRemovePlayer}
-                    onUnassignPlayer={onUnassignPlayer}
-                    onReassignPlayer={onReassignPlayer}
+                    onAssignAssessment={onAssignAssessment}
+                    onViewPlayers={onViewPlayers}
                     onViewDetails={onViewDetails}
                     onEdit={onEdit}
                     onDelete={onDelete}

--- a/frontend/src/components/GroupOverCapacityModal.tsx
+++ b/frontend/src/components/GroupOverCapacityModal.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { Fragment, useState, useEffect } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { GroupResponse } from '@/types/groups';
+import { PlayerDTO } from '@/types/players';
+import { groupsAPI } from '@/lib/api';
+
+interface GroupOverCapacityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** The group that is already at its limit. */
+  group: GroupResponse | null;
+  /** The player whose assignment hit the limit. */
+  player: PlayerDTO | null;
+  /** Called once the player has been placed, either way. */
+  onComplete: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+type Choice = 'add' | 'split';
+
+/**
+ * Offered when a player is assigned to a group that is already at its limit.
+ *
+ * The limit is a threshold, not a hard rule, so going over stays possible -
+ * but only as a deliberate choice, never silently.
+ */
+export default function GroupOverCapacityModal({
+  isOpen,
+  onClose,
+  group,
+  player,
+  onComplete,
+  onError,
+}: GroupOverCapacityModalProps) {
+  const [choice, setChoice] = useState<Choice>('split');
+  const [newGroupName, setNewGroupName] = useState('');
+  const [playerIdsToMove, setPlayerIdsToMove] = useState<number[]>([]);
+  const [newPlayerJoinsNewGroup, setNewPlayerJoinsNewGroup] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  /**
+   * Fetched fresh: the group list does not reliably carry its players, and the
+   * picker needs them. getById loads players and coach explicitly.
+   */
+  const [detail, setDetail] = useState<GroupResponse | null>(null);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen || !group) return;
+
+    setChoice('split');
+    setNewGroupName(`${group.name} B`);
+    setPlayerIdsToMove([]);
+    setNewPlayerJoinsNewGroup(true);
+    setError(null);
+    setDetail(null);
+
+    let cancelled = false;
+    setIsLoadingDetail(true);
+    groupsAPI
+      .getById(group.id)
+      .then(full => {
+        if (!cancelled) setDetail(full);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load this group\'s players.');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingDetail(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, group]);
+
+  const existingPlayers = detail?.players ?? group?.players ?? [];
+
+  const togglePlayer = (playerId: number) => {
+    setPlayerIdsToMove(prev =>
+      prev.includes(playerId) ? prev.filter(id => id !== playerId) : [...prev, playerId]
+    );
+  };
+
+  const handleAddAnyway = async () => {
+    if (!group || !player?.id) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await groupsAPI.assignPlayer({
+        playerId: player.id,
+        groupId: group.id,
+        // The limit was shown and the admin chose to go past it.
+        forceAssignment: true,
+        reason: 'Added over capacity by admin',
+      });
+      onComplete(
+        `${player.firstName} ${player.lastName} added to ${group.name}, now over its limit of ${group.capacity}`
+      );
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to add the player';
+      setError(message);
+      onError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSplit = async () => {
+    if (!group || !player?.id) return;
+
+    if (!newGroupName.trim()) {
+      setError('Give the new group a name.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const result = await groupsAPI.split(group.id, {
+        newGroupName: newGroupName.trim(),
+        playerIdsToMove,
+        newPlayerId: player.id,
+        newPlayerJoinsNewGroup,
+      });
+
+      const landedIn = newPlayerJoinsNewGroup ? result.newGroup.name : result.originalGroup.name;
+      onComplete(
+        `${result.newGroup.name} created with ${result.playersMoved} player${
+          result.playersMoved === 1 ? '' : 's'
+        } moved across. ${player.firstName} ${player.lastName} joined ${landedIn}.`
+      );
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to split the group';
+      setError(message);
+      onError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!group || !player) return null;
+
+  // From currentPlayerCount, not the loaded list: the count is authoritative
+  // and correct even while the player list is still loading.
+  const remainingInOriginal =
+    group.currentPlayerCount - playerIdsToMove.length + (newPlayerJoinsNewGroup ? 0 : 1);
+  const countInNew = playerIdsToMove.length + (newPlayerJoinsNewGroup ? 1 : 0);
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-background-modal border border-border p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title as="h3" className="text-lg font-medium text-text-primary mb-1">
+                  {group.name} is full
+                </Dialog.Title>
+                <p className="text-sm text-text-secondary mb-4">
+                  It already has {group.currentPlayerCount} of {group.capacity} players. Choose
+                  where {player.firstName} {player.lastName} should go.
+                </p>
+
+                {error && (
+                  <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                    <p className="text-sm text-accent-red">{error}</p>
+                  </div>
+                )}
+
+                <div className="space-y-3 mb-4">
+                  <label
+                    className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                      choice === 'split'
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:bg-secondary-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      checked={choice === 'split'}
+                      onChange={() => setChoice('split')}
+                      className="mt-1 h-4 w-4 text-blue-600"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-text-primary">
+                        Create a new group
+                      </span>
+                      <span className="block text-xs text-text-secondary">
+                        Takes the same level, age group and assessment. Pick who moves across.
+                      </span>
+                    </span>
+                  </label>
+
+                  <label
+                    className={`flex items-start gap-3 rounded-lg border p-3 cursor-pointer transition-colors ${
+                      choice === 'add'
+                        ? 'border-primary bg-primary/5'
+                        : 'border-border hover:bg-secondary-50'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      checked={choice === 'add'}
+                      onChange={() => setChoice('add')}
+                      className="mt-1 h-4 w-4 text-blue-600"
+                    />
+                    <span>
+                      <span className="block text-sm font-medium text-text-primary">
+                        Add to {group.name} anyway
+                      </span>
+                      <span className="block text-xs text-text-secondary">
+                        Puts the group at {group.currentPlayerCount + 1} of {group.capacity}.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+
+                {choice === 'split' && (
+                  <div className="space-y-4 border-t border-border pt-4">
+                    <div>
+                      <label className="block text-sm font-medium text-text-secondary mb-1">
+                        New group name *
+                      </label>
+                      <input
+                        type="text"
+                        value={newGroupName}
+                        onChange={e => setNewGroupName(e.target.value)}
+                        className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                        placeholder="e.g. Development Cookies B"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-text-secondary mb-1">
+                        Where does {player.firstName} go?
+                      </label>
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setNewPlayerJoinsNewGroup(true)}
+                          className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+                            newPlayerJoinsNewGroup
+                              ? 'bg-primary text-white'
+                              : 'bg-secondary-100 text-text-primary border border-border hover:bg-secondary-50'
+                          }`}
+                        >
+                          The new group
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setNewPlayerJoinsNewGroup(false)}
+                          className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+                            !newPlayerJoinsNewGroup
+                              ? 'bg-primary text-white'
+                              : 'bg-secondary-100 text-text-primary border border-border hover:bg-secondary-50'
+                          }`}
+                        >
+                          {group.name}
+                        </button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <div className="flex items-center justify-between mb-2">
+                        <label className="block text-sm font-medium text-text-secondary">
+                          Move players across ({playerIdsToMove.length} selected)
+                        </label>
+                        {existingPlayers.length > 0 && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setPlayerIdsToMove(
+                                playerIdsToMove.length === existingPlayers.length
+                                  ? []
+                                  : existingPlayers.map(p => p.id!).filter(Boolean)
+                              )
+                            }
+                            className="text-xs text-primary hover:text-primary-hover transition-colors"
+                          >
+                            {playerIdsToMove.length === existingPlayers.length
+                              ? 'Clear all'
+                              : 'Select all'}
+                          </button>
+                        )}
+                      </div>
+
+                      {isLoadingDetail ? (
+                        <div className="flex items-center gap-2 py-3">
+                          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-cyan-400"></div>
+                          <span className="text-xs text-text-secondary">Loading players...</span>
+                        </div>
+                      ) : existingPlayers.length === 0 ? (
+                        <p className="text-xs text-text-secondary">
+                          No players to move. The new group will still be created.
+                        </p>
+                      ) : (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-1 max-h-56 overflow-y-auto border border-border rounded-lg p-2">
+                          {existingPlayers.map(existing => (
+                            <label
+                              key={existing.id}
+                              className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-secondary cursor-pointer"
+                            >
+                              <input
+                                type="checkbox"
+                                checked={playerIdsToMove.includes(existing.id!)}
+                                onChange={() => togglePlayer(existing.id!)}
+                                className="h-4 w-4 rounded text-blue-600"
+                              />
+                              <span className="text-sm text-text-primary truncate">
+                                {existing.firstName} {existing.lastName}
+                              </span>
+                            </label>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
+                      <p className="text-xs text-text-secondary">
+                        Afterwards: <span className="text-text-primary">{group.name}</span> has{' '}
+                        {remainingInOriginal} of {group.capacity}, and{' '}
+                        <span className="text-text-primary">{newGroupName || 'the new group'}</span>{' '}
+                        has {countInNew} of {group.capacity}. The new group starts without a coach.
+                      </p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex gap-3 pt-5">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    disabled={isSubmitting}
+                    className="flex-1 px-4 py-2 bg-secondary-600 hover:bg-secondary-700 rounded-lg text-white transition-colors disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={choice === 'split' ? handleSplit : handleAddAnyway}
+                    disabled={isSubmitting}
+                    className="flex-1 px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 rounded-lg text-text-primary font-medium transition-all disabled:opacity-50"
+                  >
+                    {isSubmitting
+                      ? 'Working...'
+                      : choice === 'split'
+                        ? 'Create group and move'
+                        : 'Add anyway'}
+                  </button>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/GroupPlayersModal.tsx
+++ b/frontend/src/components/GroupPlayersModal.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { Fragment, useState, useEffect, useMemo } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { GroupResponse } from '@/types/groups';
+import { PlayerDTO } from '@/types/players';
+import { groupsAPI } from '@/lib/api';
+
+interface GroupPlayersModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  group: GroupResponse | null;
+  /** Something changed; the caller should re-read its groups. */
+  onChanged: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+/**
+ * A group's players, with per-player and bulk actions.
+ *
+ * The card used to list every player inline, which stopped being usable at
+ * twenty. Here they get room, a search box, and multi-select so a whole set
+ * can be moved in one action instead of one at a time.
+ */
+export default function GroupPlayersModal({
+  isOpen,
+  onClose,
+  group,
+  onChanged,
+  onError,
+}: GroupPlayersModalProps) {
+  const [players, setPlayers] = useState<PlayerDTO[]>([]);
+  const [otherGroups, setOtherGroups] = useState<GroupResponse[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
+  const [search, setSearch] = useState('');
+  const [targetGroupId, setTargetGroupId] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen || !group) return;
+
+    setSelected([]);
+    setSearch('');
+    setTargetGroupId('');
+    setError(null);
+    setIsLoading(true);
+
+    let cancelled = false;
+    Promise.all([groupsAPI.getById(group.id), groupsAPI.getAll()])
+      .then(([detail, all]) => {
+        if (cancelled) return;
+        setPlayers(detail.players ?? []);
+        setOtherGroups(
+          (all as GroupResponse[]).filter(g => g.id !== group.id && g.isActive)
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load this group\'s players');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, group]);
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return players;
+    return players.filter(p =>
+      `${p.firstName ?? ''} ${p.lastName ?? ''}`.toLowerCase().includes(q)
+    );
+  }, [players, search]);
+
+  const allVisibleSelected =
+    visible.length > 0 && visible.every(p => selected.includes(p.id!));
+
+  const toggle = (id: number) =>
+    setSelected(prev => (prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]));
+
+  const toggleAllVisible = () =>
+    setSelected(prev =>
+      allVisibleSelected
+        ? prev.filter(id => !visible.some(p => p.id === id))
+        : [...new Set([...prev, ...visible.map(p => p.id!)])]
+    );
+
+  const ageOf = (dateOfBirth?: string): number | null => {
+    if (!dateOfBirth) return null;
+    const birth = new Date(dateOfBirth);
+    if (Number.isNaN(birth.getTime())) return null;
+    const today = new Date();
+    let age = today.getFullYear() - birth.getFullYear();
+    const m = today.getMonth() - birth.getMonth();
+    if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+    return age;
+  };
+
+  /** targetId null removes the players from the group entirely. */
+  const applyMove = async (playerIds: number[], targetId: number | null) => {
+    if (!group || playerIds.length === 0) return;
+
+    const target = targetId ? otherGroups.find(g => g.id === targetId) : null;
+    const what = playerIds.length === 1 ? 'player' : `${playerIds.length} players`;
+
+    if (!targetId && !confirm(`Remove ${what} from ${group.name}? They will have no group.`)) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await groupsAPI.movePlayers(group.id, { playerIds, targetGroupId: targetId });
+      setPlayers(prev => prev.filter(p => !playerIds.includes(p.id!)));
+      setSelected(prev => prev.filter(id => !playerIds.includes(id)));
+      onChanged(
+        target
+          ? `${what} moved to ${target.name}`
+          : `${what} removed from ${group.name}`
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to move the players';
+      setError(message);
+      onError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!group) return null;
+
+  const selectedCount = selected.length;
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-background-modal border border-border p-6 text-left align-middle shadow-xl transition-all">
+                <div className="flex items-start justify-between gap-4 mb-4">
+                  <div>
+                    <Dialog.Title as="h3" className="text-lg font-medium text-text-primary">
+                      Players in {group.name}
+                    </Dialog.Title>
+                    <p className="text-xs text-text-secondary mt-0.5">
+                      {players.length} of {group.capacity}
+                      {players.length > group.capacity && ' — over the limit'}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="text-text-secondary hover:text-text-primary transition-colors"
+                    title="Close"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+
+                {error && (
+                  <div className="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded-lg">
+                    <p className="text-sm text-accent-red">{error}</p>
+                  </div>
+                )}
+
+                {players.length > 8 && (
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder="Search players by name..."
+                    className="w-full mb-3 px-3 py-2 bg-background border border-border rounded-lg text-text-primary placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                )}
+
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-400"></div>
+                  </div>
+                ) : players.length === 0 ? (
+                  <p className="text-sm text-text-secondary text-center py-12">
+                    No players in this group yet.
+                  </p>
+                ) : (
+                  <>
+                    <div className="flex items-center justify-between px-1 mb-2">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={allVisibleSelected}
+                          onChange={toggleAllVisible}
+                          className="h-4 w-4 rounded text-blue-600"
+                        />
+                        <span className="text-xs text-text-secondary">
+                          {selectedCount > 0 ? `${selectedCount} selected` : 'Select all'}
+                        </span>
+                      </label>
+                      {search && (
+                        <span className="text-xs text-text-secondary">
+                          {visible.length} of {players.length} shown
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="border border-border rounded-lg divide-y divide-border max-h-80 overflow-y-auto">
+                      {visible.length === 0 ? (
+                        <p className="text-sm text-text-secondary text-center py-8">
+                          No players match your search.
+                        </p>
+                      ) : (
+                        visible.map(player => {
+                          const age = ageOf(player.dateOfBirth);
+                          const isSelected = selected.includes(player.id!);
+                          return (
+                            <div
+                              key={player.id}
+                              className={`flex items-center gap-3 px-3 py-2.5 transition-colors ${
+                                isSelected ? 'bg-blue-500/10' : 'hover:bg-secondary-50'
+                              }`}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={isSelected}
+                                onChange={() => toggle(player.id!)}
+                                className="h-4 w-4 rounded text-blue-600 flex-shrink-0"
+                              />
+                              <div className="flex-1 min-w-0">
+                                <p className="text-sm text-text-primary truncate">
+                                  {player.firstName} {player.lastName}
+                                </p>
+                                <p className="text-xs text-text-secondary">
+                                  {age !== null && `Age ${age}`}
+                                  {player.level ? `${age !== null ? ' • ' : ''}${player.level}` : ''}
+                                </p>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => applyMove([player.id!], null)}
+                                disabled={isSubmitting}
+                                className="btn-destructive btn-xs flex-shrink-0 disabled:opacity-50"
+                                title={`Remove from ${group.name}`}
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          );
+                        })
+                      )}
+                    </div>
+                  </>
+                )}
+
+                {/* Bulk bar, only once something is selected */}
+                {selectedCount > 0 && (
+                  <div className="mt-4 rounded-lg border border-blue-500/30 bg-blue-500/10 p-3 space-y-3">
+                    <p className="text-sm text-text-primary">
+                      {selectedCount} player{selectedCount === 1 ? '' : 's'} selected
+                    </p>
+                    <div className="flex flex-col sm:flex-row gap-2">
+                      <select
+                        value={targetGroupId}
+                        onChange={e => setTargetGroupId(e.target.value)}
+                        className="flex-1 px-3 py-2 bg-background border border-border rounded-lg text-text-primary focus:outline-none focus:ring-2 focus:ring-primary"
+                      >
+                        <option value="">Move to...</option>
+                        {otherGroups.map(g => (
+                          <option key={g.id} value={g.id}>
+                            {g.name} ({g.currentPlayerCount}/{g.capacity})
+                            {g.isFull ? ' — full' : ''}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        disabled={!targetGroupId || isSubmitting}
+                        onClick={() => applyMove(selected, Number(targetGroupId))}
+                        className="px-4 py-2 bg-primary hover:bg-primary-hover rounded-lg text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Move
+                      </button>
+                      <button
+                        type="button"
+                        disabled={isSubmitting}
+                        onClick={() => applyMove(selected, null)}
+                        className="px-4 py-2 bg-red-500/10 hover:bg-red-500/20 border border-red-500/20 rounded-lg text-accent-red text-sm font-medium transition-colors disabled:opacity-50"
+                      >
+                        Remove from group
+                      </button>
+                    </div>
+                    <p className="text-xs text-text-secondary">
+                      A full destination is still offered; moving into one puts it over its limit.
+                    </p>
+                  </div>
+                )}
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -52,10 +52,10 @@ export default function ProtectedRoute({
   // Show loading state while checking authentication
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-900 via-blue-800 to-cyan-700 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-background to-secondary-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-white mx-auto mb-4"></div>
-          <p className="text-white">Verifying authentication...</p>
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-text-primary">Verifying authentication...</p>
         </div>
       </div>
     );

--- a/frontend/src/components/ReassignPlayerModal.tsx
+++ b/frontend/src/components/ReassignPlayerModal.tsx
@@ -16,6 +16,44 @@ interface ReassignPlayerModalProps {
   isLoading?: boolean;
 }
 
+
+/**
+ * Why a target group may not suit this player. Empty means a clean fit.
+ *
+ * These never block the move: an admin moving a player by hand may be doing it
+ * on purpose, for a trial or a mid-season promotion.
+ */
+function fitWarnings(player: PlayerDTO | null, group: GroupResponse): string[] {
+  const warnings: string[] = [];
+
+  if (group.isFull) {
+    warnings.push(`already at ${group.currentPlayerCount}/${group.capacity}`);
+  }
+
+  if (player?.level && group.level && player.level !== group.level) {
+    warnings.push(`${group.level.toLowerCase()} group, player is ${player.level.toLowerCase()}`);
+  }
+
+  if (player?.dateOfBirth) {
+    const birth = new Date(player.dateOfBirth);
+    if (!Number.isNaN(birth.getTime())) {
+      const today = new Date();
+      let age = today.getFullYear() - birth.getFullYear();
+      const monthDiff = today.getMonth() - birth.getMonth();
+      if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) age--;
+      if (age < group.minAge || age > group.maxAge) {
+        warnings.push(`age ${age} is outside ${group.minAge}-${group.maxAge}`);
+      }
+    }
+  }
+
+  if (!group.assessmentTemplateId) {
+    warnings.push('no assessment assigned, so the player could not be assessed');
+  }
+
+  return warnings;
+}
+
 export default function ReassignPlayerModal({
   isOpen,
   onClose,
@@ -43,24 +81,25 @@ export default function ReassignPlayerModal({
     
     try {
       const groups = await groupsAPI.getAll();
-      // Filter out the current group and show groups that aren't full
-      const availableForReassignment = groups.filter((group: GroupResponse) => 
-        group.id !== currentGroupId && 
-        !group.isFull && 
+      // Every active group is offered, full ones included. A move is a
+      // deliberate act by an admin, so an unsuitable target is warned about
+      // rather than hidden - hiding it just looks like the group is missing.
+      const availableForReassignment = groups.filter((group: GroupResponse) =>
+        group.id !== currentGroupId &&
         group.isActive
       );
-      
+
       // Sort groups consistently
       availableForReassignment.sort((a: GroupResponse, b: GroupResponse) => {
         const nameComparison = a.name.localeCompare(b.name);
         if (nameComparison !== 0) return nameComparison;
         return a.id - b.id;
       });
-      
+
       setAvailableGroups(availableForReassignment);
-      
+
       if (availableForReassignment.length === 0) {
-        setError('No available groups for reassignment');
+        setError('There are no other active groups to move this player to');
       }
     } catch (err) {
       console.error('Failed to load groups for reassignment:', err);
@@ -96,7 +135,7 @@ export default function ReassignPlayerModal({
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-25 backdrop-blur-sm" />
+          <div className="fixed inset-0 bg-black bg-opacity-50" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -110,8 +149,8 @@ export default function ReassignPlayerModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-visible bg-white/10 backdrop-blur-sm border border-white/20 rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
-                <Dialog.Title className="text-lg font-medium text-white mb-4 flex items-center">
+              <Dialog.Panel className="w-full max-w-md transform overflow-visible bg-background-modal border border-border rounded-2xl p-6 text-left align-middle shadow-xl transition-all">
+                <Dialog.Title className="text-lg font-medium text-text-primary mb-4 flex items-center">
                   <svg className="w-6 h-6 text-text-primary mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
                   </svg>
@@ -126,7 +165,7 @@ export default function ReassignPlayerModal({
 
                 <div className="mb-6">
                   <p className="text-sm text-text-secondary mb-4">
-                    Move <strong className="text-white">{player?.firstName} {player?.lastName}</strong> from <strong className="text-white">{currentGroupName}</strong> to a new group:
+                    Move <strong className="text-text-primary">{player?.firstName} {player?.lastName}</strong> from <strong className="text-text-primary">{currentGroupName}</strong> to a new group:
                   </p>
                   
                   {loadingGroups ? (
@@ -141,7 +180,7 @@ export default function ReassignPlayerModal({
                       </label>
                       <Listbox value={selectedGroup} onChange={setSelectedGroup}>
                         <div className="relative">
-                          <Listbox.Button className="w-full px-3 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg text-white text-left focus:outline-none focus:ring-2 focus:ring-cyan-400 flex items-center justify-between">
+                          <Listbox.Button className="w-full px-3 py-2 bg-background border border-border rounded-lg text-text-primary text-left focus:outline-none focus:ring-2 focus:ring-cyan-400 flex items-center justify-between">
                             <span>
                               {selectedGroup 
                                 ? `${selectedGroup.name} - ${selectedGroup.level} (${selectedGroup.availableSpots} spots)`
@@ -151,18 +190,23 @@ export default function ReassignPlayerModal({
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                             </svg>
                           </Listbox.Button>
-                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-gray-800 border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-auto">
+                          <Listbox.Options className="absolute z-50 mt-1 w-full bg-background-modal border border-border rounded-lg shadow-lg max-h-40 overflow-auto">
                             {availableGroups.map((group) => (
                               <Listbox.Option
                                 key={group.id}
                                 value={group}
-                                className="px-3 py-2 hover:bg-gray-700 cursor-pointer text-white"
+                                className="px-3 py-2 hover:bg-secondary-100 cursor-pointer text-text-primary"
                               >
                                 <div>
                                   <div className="font-medium">{group.name}</div>
                                   <div className="text-sm text-text-secondary">
-                                    {group.level} • {group.availableSpots} spots available
+                                    {group.level} • {group.currentPlayerCount}/{group.capacity} players
                                   </div>
+                                  {fitWarnings(player, group).length > 0 && (
+                                    <div className="text-xs text-accent-yellow mt-0.5">
+                                      {fitWarnings(player, group).join(' · ')}
+                                    </div>
+                                  )}
                                 </div>
                               </Listbox.Option>
                             ))}
@@ -175,23 +219,41 @@ export default function ReassignPlayerModal({
                       <svg className="mx-auto h-12 w-12 text-text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v2m-2-6a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                       </svg>
-                      <h3 className="mt-2 text-sm font-medium text-text-secondary">No available groups</h3>
+                      <h3 className="mt-2 text-sm font-medium text-text-secondary">Nowhere to move them</h3>
                       <p className="mt-1 text-sm text-text-secondary">
-                        All other groups are either full or inactive.
+                        There are no other active groups.
                       </p>
                     </div>
                   )}
                   
-                  {selectedGroup && (
-                    <div className="mt-4 bg-blue-500/20 border border-blue-500/30 rounded-lg p-3">
-                      <p className="text-sm text-text-secondary">
-                        <strong>Moving to:</strong> {selectedGroup.name}
-                      </p>
-                      <p className="text-xs text-text-secondary">
-                        {selectedGroup.level} • {selectedGroup.availableSpots} spots available after assignment
-                      </p>
-                    </div>
-                  )}
+                  {selectedGroup && (() => {
+                    const warnings = fitWarnings(player, selectedGroup);
+                    return (
+                      <div
+                        className={`mt-4 rounded-lg p-3 border ${
+                          warnings.length > 0
+                            ? 'bg-yellow-500/10 border-yellow-500/30'
+                            : 'bg-blue-500/20 border-blue-500/30'
+                        }`}
+                      >
+                        <p className="text-sm text-text-primary">
+                          <strong>Moving to:</strong> {selectedGroup.name}
+                        </p>
+                        <p className="text-xs text-text-secondary">
+                          {selectedGroup.level} • {selectedGroup.currentPlayerCount}/{selectedGroup.capacity} players
+                        </p>
+                        {warnings.length > 0 && (
+                          <ul className="mt-2 space-y-0.5">
+                            {warnings.map((warning) => (
+                              <li key={warning} className="text-xs text-accent-yellow">
+                                • {warning}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    );
+                  })()}
                 </div>
 
                 <div className="flex gap-3">

--- a/frontend/src/components/ResetPasswordModal.tsx
+++ b/frontend/src/components/ResetPasswordModal.tsx
@@ -87,7 +87,7 @@ export default function ResetPasswordModal({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-background-modal border border-border p-6 text-left align-middle shadow-xl transition-all">
                 {done ? (
                   <>
                     <Dialog.Title className="text-lg font-semibold text-gray-900">

--- a/frontend/src/components/RoleGuard.tsx
+++ b/frontend/src/components/RoleGuard.tsx
@@ -55,8 +55,8 @@ export const withRoleGuard = <P extends object>(
 
       return (
         <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900 flex items-center justify-center">
-          <div className="bg-white/10 backdrop-blur-lg rounded-xl p-8 border border-white/20 text-center">
-            <h2 className="text-2xl font-bold text-white mb-4">
+          <div className="bg-background rounded-xl p-8 border border-border text-center">
+            <h2 className="text-2xl font-bold text-text-primary mb-4">
               Access Denied
             </h2>
             <p className="text-blue-200 mb-6">

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -395,7 +395,7 @@ export default function UserCard({
 
       {/* Address */}
       {user.address && (
-        <div className="mt-4 pt-4 border-t border-white/10">
+        <div className="mt-4 pt-4 border-t border-border">
           <div className="flex items-center text-primary mb-1">
             <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />

--- a/frontend/src/components/assessments/AssessmentManagement.tsx
+++ b/frontend/src/components/assessments/AssessmentManagement.tsx
@@ -143,10 +143,10 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
       {/* Header */}
       {viewMode === 'list' && (
         <>
-          <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl p-6">
+          <div className="bg-background border border-border rounded-xl p-6">
             <div className="flex items-center justify-between">
               <div>
-                <h1 className="text-2xl font-bold text-white">Assessment Management</h1>
+                <h1 className="text-2xl font-bold text-text-primary">Assessment Management</h1>
                 <p className="text-text-secondary mt-1">
                   {playerId ? 'Player assessment history and progress' : 'Manage player assessments and track progress'}
                 </p>
@@ -156,7 +156,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
                 <button
                   onClick={loadData}
                   disabled={loading}
-                  className="p-2 text-text-secondary hover:text-white hover:bg-white/20 rounded-lg transition-colors"
+                  className="p-2 text-text-secondary hover:text-text-primary hover:bg-secondary-100 rounded-lg transition-colors"
                   title="Refresh"
                 >
                   <RefreshCw size={20} className={loading ? 'animate-spin' : ''} />
@@ -164,7 +164,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
 
                 <button
                   onClick={() => setViewMode('analytics')}
-                  className="flex items-center gap-2 px-4 py-2 border border-white/30 text-white rounded-lg hover:bg-white/20 transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 border border-border text-text-primary rounded-lg hover:bg-secondary-100 transition-colors"
                 >
                   <BarChart3 size={16} />
                   Analytics
@@ -197,7 +197,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
 
           {/* Quick Stats */}
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-4">
+            <div className="bg-background border border-border rounded-lg p-4">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-600">Total Assessments</p>
@@ -207,7 +207,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
               </div>
             </div>
 
-            <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-4">
+            <div className="bg-background border border-border rounded-lg p-4">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-600">Completed</p>
@@ -217,7 +217,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
               </div>
             </div>
 
-            <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-4">
+            <div className="bg-background border border-border rounded-lg p-4">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-600">In Progress</p>
@@ -227,7 +227,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
               </div>
             </div>
 
-            <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-lg p-4">
+            <div className="bg-background border border-border rounded-lg p-4">
               <div className="flex items-center justify-between">
                 <div>
                   <p className="text-sm text-gray-600">This Month</p>
@@ -249,7 +249,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
 
                   return (
                     <div key={category.key} className="text-center">
-                      <div className={`w-12 h-12 rounded-full ${category.color} flex items-center justify-center text-white text-xl mx-auto mb-2`}>
+                      <div className={`w-12 h-12 rounded-full ${category.color} flex items-center justify-center text-text-primary text-xl mx-auto mb-2`}>
                         {category.icon}
                       </div>
                       <p className="font-medium text-gray-900">{category.label}</p>
@@ -276,7 +276,7 @@ export const AssessmentManagement: React.FC<AssessmentManagementProps> = ({
       {/* Content Area */}
       <div>
         {viewMode === 'list' && (
-          <div className="bg-white/10 backdrop-blur-sm border border-white/20 rounded-xl">
+          <div className="bg-background border border-border rounded-xl">
             <div className="p-6">
               <AssessmentList
                 assessments={assessments}

--- a/frontend/src/components/skills/SkillCard.tsx
+++ b/frontend/src/components/skills/SkillCard.tsx
@@ -115,7 +115,7 @@ export default function SkillCard({
             ${skill.isActive ? 'after:bg-green-400/50' : 'after:bg-red-400/50'}
           `} />
           {!skill.isActive && (
-            <span className="text-xs px-2 py-1 bg-red-500/20 text-red-300 rounded-lg border border-red-400/30 backdrop-blur-sm">
+            <span className="text-xs px-2 py-1 bg-red-500/20 text-accent-red rounded-lg border border-red-500/20">
               Inactive
             </span>
           )}
@@ -208,7 +208,7 @@ export default function SkillCard({
                   </button>
                 ) : (
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-red-300 font-medium">Confirm?</span>
+                    <span className="text-xs text-accent-red font-medium">Confirm?</span>
                     <button
                       onClick={handleConfirmDelete}
                       className="

--- a/frontend/src/components/skills/SkillCategoryTabs.tsx
+++ b/frontend/src/components/skills/SkillCategoryTabs.tsx
@@ -34,7 +34,7 @@ export default function SkillCategoryTabs({
       color: 'bg-gradient-to-br from-gray-600 to-gray-700',
       bgColor: 'bg-gray-500/20',
       borderColor: 'border-gray-400/30',
-      textColor: 'text-gray-300',
+      textColor: 'text-text-secondary',
       description: 'View all skills across categories'
     },
     ...SKILL_CATEGORIES
@@ -59,7 +59,7 @@ export default function SkillCategoryTabs({
                 hover:z-20 focus:z-20 focus:outline-none focus:ring-2 focus:ring-primary/50
                 active:scale-100
                 ${isActive
-                  ? `${tab.color} text-white shadow-xl scale-105 border-2 border-white/40`
+                  ? `${tab.color} text-white shadow-xl scale-105 border-2 border-border`
                   : 'text-text-primary hover:text-white hover:shadow-lg bg-background border border-border hover:border-transparent hover:bg-gradient-to-br hover:from-primary hover:to-primary-dark'
                 }
               `}
@@ -100,8 +100,8 @@ export default function SkillCategoryTabs({
                       } animate-pulse`} />
                       <span className={`font-medium ${
                         activeCount === totalCount
-                          ? (isActive ? 'text-green-200' : 'text-green-400')
-                          : (isActive ? 'text-yellow-200' : 'text-yellow-400')
+                          ? (isActive ? 'text-green-600' : 'text-green-400')
+                          : (isActive ? 'text-accent-yellow' : 'text-yellow-400')
                       }`}>
                         {activeCount} active
                       </span>
@@ -115,7 +115,7 @@ export default function SkillCategoryTabs({
                 ml-auto px-3 py-1.5 rounded-lg text-xs font-bold transition-all duration-300
                 flex items-center gap-1.5 shadow-lg
                 ${isActive
-                  ? 'bg-black/20 text-white border border-white/30'
+                  ? 'bg-black/20 text-white border border-border'
                   : 'bg-secondary text-text-primary border border-border'
                 }
                 group-hover:scale-105
@@ -157,7 +157,7 @@ export default function SkillCategoryTabs({
                     <p className="text-text-secondary text-sm">
                       {totalCount} skills in this category
                       {activeCount < totalCount && (
-                        <span className="inline-flex items-center gap-1 ml-2 px-2 py-0.5 bg-yellow-600 border border-yellow-500 rounded-md text-yellow-200 text-xs font-medium">
+                        <span className="inline-flex items-center gap-1 ml-2 px-2 py-0.5 bg-yellow-600 border border-yellow-500 rounded-md text-accent-yellow text-xs font-medium">
                           <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92z" clipRule="evenodd" />
                           </svg>

--- a/frontend/src/components/skills/SkillForm.tsx
+++ b/frontend/src/components/skills/SkillForm.tsx
@@ -91,13 +91,13 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
   const isEditMode = !!skill;
 
   return (
-    <div className="relative bg-gradient-to-br from-white/15 to-white/5 backdrop-blur-xl rounded-2xl border border-white/20 shadow-2xl p-8 max-w-2xl mx-auto overflow-hidden">
+    <div className="relative bg-background-modal rounded-2xl border border-border shadow-lg p-8 max-w-2xl mx-auto overflow-hidden">
       {/* Decorative background elements */}
       <div className="absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-blue-500/10 to-purple-500/10 rounded-full blur-3xl" />
       <div className="absolute bottom-0 left-0 w-24 h-24 bg-gradient-to-tr from-green-500/10 to-cyan-500/10 rounded-full blur-2xl" />
 
       <div className="relative z-10">
-        <div className="flex items-center justify-between mb-8 pb-6 border-b border-white/20">
+        <div className="flex items-center justify-between mb-8 pb-6 border-b border-border">
           <div className="flex items-center gap-4">
             <div className="relative p-3 bg-gradient-to-br from-blue-500 to-purple-600 rounded-xl shadow-lg">
               <svg className="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -109,7 +109,7 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
               <h3 className="text-2xl font-bold text-white mb-1">
                 {isEditMode ? 'Edit Skill' : 'Create New Skill'}
               </h3>
-              <p className="text-gray-300 text-sm">
+              <p className="text-text-secondary text-sm">
                 {isEditMode ? 'Update skill details and settings' : 'Add a new skill to the system'}
               </p>
             </div>
@@ -119,9 +119,9 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
             onClick={onCancel}
             disabled={isSubmitting}
             className="
-              p-2 rounded-xl bg-white/10 hover:bg-white/20 text-gray-300 hover:text-white
-              transition-all duration-300 hover:scale-105 backdrop-blur-sm
-              border border-white/20 hover:border-white/30
+              p-2 rounded-xl bg-secondary-100 hover:bg-secondary-50 text-text-secondary hover:text-text-primary
+              transition-all duration-300 hover:scale-105
+              border border-border hover:border-border
             "
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -148,11 +148,11 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 onChange={(e) => handleChange('name', e.target.value)}
                 className={`
                   w-full px-4 py-3 pr-16 rounded-xl transition-all duration-300
-                  bg-white/5 border backdrop-blur-sm text-white placeholder-gray-400
+                  bg-background border text-text-primary placeholder-text-secondary
                   focus:outline-none focus:ring-2 focus:scale-[1.02]
                   ${errors.name
                     ? 'border-red-400/50 focus:border-red-400 focus:ring-red-400/30 bg-red-500/5'
-                    : 'border-white/20 focus:border-primary focus:ring-primary/30 hover:border-white/30'
+                    : 'border-border focus:border-primary focus:ring-primary/30 hover:border-border'
                   }
                   group-hover:shadow-lg
                 `}
@@ -160,12 +160,12 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 disabled={isSubmitting}
                 maxLength={100}
               />
-              <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 text-sm transition-colors duration-300 group-focus-within:text-primary">
+              <div className="absolute right-3 top-1/2 transform -translate-y-1/2 text-text-secondary text-sm transition-colors duration-300 group-focus-within:text-primary">
                 {formData.name.length}/100
               </div>
             </div>
             {errors.name && (
-              <div className="mt-3 flex items-center gap-2 text-red-300 text-sm bg-red-500/10 border border-red-400/30 rounded-lg p-3 backdrop-blur-sm">
+              <div className="mt-3 flex items-center gap-2 text-accent-red text-sm bg-red-500/10 border border-red-500/20 rounded-lg p-3">
                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                 </svg>
@@ -193,14 +193,14 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                   disabled={isSubmitting || (isEditMode && skill?.usageCount > 0)}
                   className={`
                     group relative flex items-center gap-4 p-4 rounded-xl transition-all duration-300
-                    backdrop-blur-sm border overflow-hidden
+ border overflow-hidden
                     ${formData.category === category.key
                       ? `${category.color} border-white/30 text-white shadow-2xl scale-105 ring-2 ring-white/20`
                       : `${category.bgColor} ${category.borderColor} ${category.textColor} hover:scale-105 hover:shadow-xl`
                     }
                     ${(isSubmitting || (isEditMode && skill?.usageCount > 0))
                       ? 'opacity-50 cursor-not-allowed'
-                      : 'hover:border-white/40 cursor-pointer'
+                      : 'hover:border-border cursor-pointer'
                     }
                     before:absolute before:inset-0 before:bg-white/5 before:opacity-0
                     before:transition-opacity before:duration-300 hover:before:opacity-100
@@ -220,7 +220,7 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                     </div>
                   </div>
                   {formData.category === category.key && (
-                    <div className="absolute top-2 right-2 w-6 h-6 bg-white/30 rounded-full flex items-center justify-center backdrop-blur-sm shadow-lg">
+                    <div className="absolute top-2 right-2 w-6 h-6 bg-white/30 rounded-full flex items-center justify-center shadow-lg">
                       <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
                         <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                       </svg>
@@ -230,7 +230,7 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
               ))}
             </div>
             {isEditMode && skill?.usageCount > 0 && (
-              <div className="mt-4 flex items-center gap-3 text-yellow-300 text-sm bg-yellow-500/10 border border-yellow-400/30 rounded-xl p-4 backdrop-blur-sm">
+              <div className="mt-4 flex items-center gap-3 text-accent-yellow text-sm bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4">
                 <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                 </svg>
@@ -243,14 +243,14 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
           <div>
             <label className="flex items-center gap-2 text-sm font-semibold text-white mb-4">
               <div className="p-1 bg-green-500/20 rounded-lg">
-                <svg className="w-4 h-4 text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
               </div>
               Applicable Levels *
             </label>
-            <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl p-6 border border-white/20 shadow-lg">
-              <p className="text-gray-300 text-sm mb-6 text-center font-medium">
+            <div className="bg-secondary-50 rounded-xl p-6 border border-border shadow-lg">
+              <p className="text-text-secondary text-sm mb-6 text-center font-medium">
                 Select which levels this skill applies to
               </p>
               <div className="flex gap-4 justify-center">
@@ -279,10 +279,10 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                       disabled={isSubmitting || (isEditMode && skill?.usageCount > 0)}
                       className={`
                         relative flex flex-col items-center p-5 rounded-xl border-2 transition-all duration-300
-                        transform hover:scale-110 min-w-[140px] group backdrop-blur-sm shadow-lg
+                        transform hover:scale-110 min-w-[140px] group shadow-lg
                         ${isSelected
                           ? `${level.color} border-white/40 text-white shadow-2xl scale-105 ring-2 ring-white/30`
-                          : `${level.bgColor} ${level.borderColor} ${level.textColor} hover:shadow-xl hover:border-white/30`
+                          : `${level.bgColor} ${level.borderColor} ${level.textColor} hover:shadow-xl hover:border-border`
                         }
                         ${(isSubmitting || (isEditMode && skill?.usageCount > 0))
                           ? 'opacity-50 cursor-not-allowed transform-none'
@@ -298,11 +298,11 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                     >
                       {/* Selection indicator */}
                       <div className={`
-                        absolute -top-2 -right-2 w-7 h-7 rounded-full border-2 border-white/30
-                        transition-all duration-300 backdrop-blur-sm shadow-lg
+                        absolute -top-2 -right-2 w-7 h-7 rounded-full border-2 border-border
+                        transition-all duration-300 shadow-lg
                         ${isSelected
                           ? 'bg-gradient-to-r from-green-400 to-emerald-500 scale-100'
-                          : 'bg-white/10 scale-0 group-hover:scale-100'
+                          : 'bg-secondary-100 scale-0 group-hover:scale-100'
                         }
                       `}>
                         {isSelected && (
@@ -332,8 +332,8 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                       {/* Cannot remove indicator */}
                       {isLastSelected && (
                         <div className="absolute -bottom-2 left-1/2 transform -translate-x-1/2">
-                          <div className="bg-yellow-400/30 border border-yellow-400/50 rounded-lg px-3 py-1 backdrop-blur-sm shadow-lg">
-                            <span className="text-yellow-200 text-xs font-bold">Required</span>
+                          <div className="bg-yellow-400/30 border border-yellow-400/50 rounded-lg px-3 py-1 shadow-lg">
+                            <span className="text-accent-yellow text-xs font-bold">Required</span>
                           </div>
                         </div>
                       )}
@@ -345,17 +345,17 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
               {/* Both levels selected indicator */}
               {formData.applicableLevels.length === 2 && (
                 <div className="mt-6 text-center">
-                  <div className="inline-flex items-center gap-3 bg-gradient-to-r from-green-500/25 to-cyan-500/25 border border-green-400/40 rounded-xl px-6 py-3 backdrop-blur-sm shadow-lg">
-                    <span className="text-cyan-300 text-xl animate-pulse">✨</span>
-                    <span className="text-cyan-200 text-sm font-bold">Available for all levels</span>
-                    <span className="text-cyan-300 text-xl animate-pulse">✨</span>
+                  <div className="inline-flex items-center gap-3 bg-gradient-to-r from-green-500/25 to-cyan-500/25 border border-green-400/40 rounded-xl px-6 py-3 shadow-lg">
+                    <span className="text-primary text-xl animate-pulse">✨</span>
+                    <span className="text-primary text-sm font-bold">Available for all levels</span>
+                    <span className="text-primary text-xl animate-pulse">✨</span>
                   </div>
                 </div>
               )}
             </div>
 
             {(errors as any).applicableLevels && (
-              <div className="mt-4 flex items-center gap-3 text-red-300 text-sm bg-red-500/10 border border-red-400/30 rounded-xl p-4 backdrop-blur-sm">
+              <div className="mt-4 flex items-center gap-3 text-accent-red text-sm bg-red-500/10 border border-red-500/20 rounded-xl p-4">
                 <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                 </svg>
@@ -364,7 +364,7 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
             )}
 
             {isEditMode && skill?.usageCount > 0 && (
-              <div className="mt-4 flex items-center gap-3 text-yellow-300 text-sm bg-yellow-500/10 border border-yellow-400/30 rounded-xl p-4 backdrop-blur-sm">
+              <div className="mt-4 flex items-center gap-3 text-accent-yellow text-sm bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4">
                 <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                 </svg>
@@ -390,11 +390,11 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 rows={4}
                 className={`
                   w-full px-4 py-3 pr-16 rounded-xl transition-all duration-300 resize-none
-                  bg-white/5 border backdrop-blur-sm text-white placeholder-gray-400
+                  bg-background border text-text-primary placeholder-text-secondary
                   focus:outline-none focus:ring-2 focus:scale-[1.02]
                   ${errors.description
                     ? 'border-red-400/50 focus:border-red-400 focus:ring-red-400/30 bg-red-500/5'
-                    : 'border-white/20 focus:border-amber-400 focus:ring-amber-400/30 hover:border-white/30'
+                    : 'border-border focus:border-amber-400 focus:ring-amber-400/30 hover:border-border'
                   }
                   group-hover:shadow-lg
                 `}
@@ -402,12 +402,12 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 disabled={isSubmitting}
                 maxLength={500}
               />
-              <div className="absolute bottom-3 right-3 text-gray-400 text-xs transition-colors duration-300 group-focus-within:text-amber-300">
+              <div className="absolute bottom-3 right-3 text-text-secondary text-xs transition-colors duration-300 group-focus-within:text-amber-300">
                 {formData.description.length}/500
               </div>
             </div>
             {errors.description && (
-              <div className="mt-3 flex items-center gap-2 text-red-300 text-sm bg-red-500/10 border border-red-400/30 rounded-lg p-3 backdrop-blur-sm">
+              <div className="mt-3 flex items-center gap-2 text-accent-red text-sm bg-red-500/10 border border-red-500/20 rounded-lg p-3">
                 <svg className="w-4 h-4 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
                 </svg>
@@ -417,18 +417,18 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
           </div>
 
           {/* Active Status */}
-          <div className="bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-sm rounded-xl p-5 border border-white/20 shadow-lg">
+          <div className="bg-secondary-50 rounded-xl p-5 border border-border shadow-lg">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-4">
                 <div className={`
                   p-2 rounded-xl transition-all duration-300
                   ${formData.isActive
                     ? 'bg-gradient-to-br from-green-500/20 to-emerald-500/20'
-                    : 'bg-gradient-to-br from-gray-500/20 to-gray-600/20'
+                    : 'bg-gradient-to-br from-secondary-100 to-secondary-50'
                   }
                 `}>
                   <svg className={`w-6 h-6 transition-colors duration-300 ${
-                    formData.isActive ? 'text-green-300' : 'text-gray-400'
+                    formData.isActive ? 'text-green-600' : 'text-text-secondary'
                   }`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
                       d={formData.isActive
@@ -439,11 +439,11 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                   </svg>
                 </div>
                 <div>
-                  <label htmlFor="isActive" className="text-base font-bold text-white cursor-pointer mb-1 block">
+                  <label htmlFor="isActive" className="text-base font-bold text-text-primary cursor-pointer mb-1 block">
                     Skill Status
                   </label>
                   <p className={`text-sm transition-colors duration-300 ${
-                    formData.isActive ? 'text-green-200' : 'text-gray-400'
+                    formData.isActive ? 'text-green-600' : 'text-text-secondary'
                   }`}>
                     {formData.isActive ? 'Active and available for assessments' : 'Inactive and hidden from assessments'}
                   </p>
@@ -456,7 +456,7 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 disabled={isSubmitting}
                 className={`
                   relative inline-flex h-8 w-14 items-center rounded-full border-2 transition-all duration-300
-                  focus:outline-none focus:ring-2 shadow-lg backdrop-blur-sm
+                  focus:outline-none focus:ring-2 shadow-lg
                   ${formData.isActive
                     ? 'bg-gradient-to-r from-green-500 to-emerald-600 border-green-400/50 focus:ring-green-400/50'
                     : 'bg-gradient-to-r from-gray-600 to-gray-700 border-gray-500/50 focus:ring-gray-400/50'
@@ -488,15 +488,15 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
           </div>
 
           {/* Form Actions */}
-          <div className="flex justify-end gap-4 pt-8 border-t border-white/20">
+          <div className="flex justify-end gap-4 pt-8 border-t border-border">
             <button
               type="button"
               onClick={onCancel}
               disabled={isSubmitting}
               className="
                 px-6 py-3 rounded-xl text-sm font-semibold transition-all duration-300
-                bg-white/10 text-gray-300 border border-white/20 hover:bg-white/20 hover:text-white
-                hover:scale-105 backdrop-blur-sm shadow-lg
+                bg-secondary-100 text-text-primary border border-border hover:bg-secondary-50
+                hover:scale-105 shadow-lg
                 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none
               "
             >
@@ -510,11 +510,11 @@ export default function SkillForm({ skill, onSubmit, onCancel, isLoading = false
                 bg-gradient-to-r from-primary to-secondary text-white border border-primary/30
                 hover:from-blue-600 hover:to-purple-700 hover:scale-105 shadow-xl
                 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none
-                backdrop-blur-sm
+
               "
             >
               {(isSubmitting || isLoading) && (
-                <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                <div className="w-4 h-4 border-2 border-border border-t-white rounded-full animate-spin" />
               )}
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}

--- a/frontend/src/components/skills/SkillsManagement.tsx
+++ b/frontend/src/components/skills/SkillsManagement.tsx
@@ -303,7 +303,7 @@ export default function SkillsManagement() {
                 disabled={currentPage === 0}
                 className={`p-2 rounded-lg transition-colors ${
                   currentPage === 0
-                    ? 'bg-white/5 text-disabled cursor-not-allowed'
+                    ? 'bg-secondary-50 text-disabled cursor-not-allowed'
                     : 'bg-secondary-50 text-text-primary hover:bg-secondary-100'
                 }`}
               >
@@ -322,7 +322,7 @@ export default function SkillsManagement() {
                         onClick={() => setCurrentPage(i)}
                         className={`px-3 py-1 rounded-lg transition-colors ${
                           i === currentPage
-                            ? 'bg-cyan-600 text-text-primary'
+                            ? 'bg-cyan-600 text-white'
                             : 'bg-secondary-50 text-text-primary hover:bg-secondary-100'
                         }`}
                       >
@@ -343,7 +343,7 @@ export default function SkillsManagement() {
                 disabled={currentPage === totalPages - 1}
                 className={`p-2 rounded-lg transition-colors ${
                   currentPage === totalPages - 1
-                    ? 'bg-white/5 text-disabled cursor-not-allowed'
+                    ? 'bg-secondary-50 text-disabled cursor-not-allowed'
                     : 'bg-secondary-50 text-text-primary hover:bg-secondary-100'
                 }`}
               >
@@ -461,7 +461,7 @@ export default function SkillsManagement() {
               </button>
               <button
                 onClick={handleInitializeDefaults}
-                className="px-6 py-2 bg-purple-600 hover:bg-purple-700 text-text-primary rounded-lg font-medium transition-colors"
+                className="px-6 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors"
               >
                 Initialize Skills
               </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,7 @@ import {
   UserResponse,
 } from "@/types/auth";
 import { CreatePlayersRequest, CreatePlayersResponse } from "@/types/players";
+import { GroupResponse } from "@/types/groups";
 import {
   AssessmentTemplate,
   AssessmentTemplateRequest,
@@ -620,6 +621,44 @@ export const groupsAPI = {
     return apiRequest<any>("/groups/assign-player", {
       method: "POST",
       body: JSON.stringify(assignmentData),
+    });
+  },
+
+  // Relieve a full group by creating a sibling that inherits its level, age
+  // group and assessment, and moving the chosen players across. One
+  // transaction, so a failure cannot leave a half-populated group behind.
+  split: async (
+    groupId: number,
+    request: {
+      newGroupName: string;
+      playerIdsToMove?: number[];
+      newPlayerId?: number;
+      newPlayerJoinsNewGroup?: boolean;
+    }
+  ): Promise<{
+    originalGroup: GroupResponse;
+    newGroup: GroupResponse;
+    playersMoved: number;
+  }> => {
+    return apiRequest(`/groups/${groupId}/split`, {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  },
+
+  // Move or unassign several of a group's players at once. A null
+  // targetGroupId leaves them unassigned. One transaction.
+  movePlayers: async (
+    groupId: number,
+    request: { playerIds: number[]; targetGroupId?: number | null }
+  ): Promise<{
+    originalGroup: GroupResponse;
+    newGroup: GroupResponse | null;
+    playersMoved: number;
+  }> => {
+    return apiRequest(`/groups/${groupId}/players/move`, {
+      method: "POST",
+      body: JSON.stringify(request),
     });
   },
 


### PR DESCRIPTION
## Capacity

Standard group size is now **20**, applied to existing groups and the column default. Capacity stays per-group, so a group can still be deliberately larger or smaller.

The limit is a **threshold, not a hard rule**. Assigning to a full group now offers a choice instead of an error:

- **Add anyway** — puts the group over its limit, deliberately and never silently
- **Split** — creates a sibling carrying the same level, age group and assessment (**not** the coach, since one coach rarely takes both), moves the players you pick, and puts the new player in whichever group you chose

One transaction, so a failure cannot leave a half-populated group behind.

## Players moved into a dialog

The card listed every player inline, which stopped being usable well before twenty and buried the actions underneath. **View Players** now opens a dialog with room, a search box once a group passes eight, and **multi-select** for bulk move or bulk remove.

Moves go through one transactional endpoint — looping in the browser leaves a half-finished move with no way to tell what landed.

## Moving between groups

Every active group is now offered, **including full ones and ones that don't match on age or level**, with the mismatch spelled out. Hiding an unsuitable group looks identical to the group not existing, and an admin moving someone by hand may be doing it on purpose.

## Card fixes

Assign-assessment action, equal-width buttons, and a delete icon that is actually a bin — the old paths drew a circle with two slots cut out of it.

## Two bugs found while building this

**Every group response in the app carried an empty player list.** `GroupResponse` hardcoded `List.of()` with a comment saying the service layer would populate it; it never did. The count came from elsewhere, which is why a group could report "5 of 5" above an empty list — and why the per-player actions on the card were unreachable. Now populated, guarded on initialisation, and fetched for a whole page in one query rather than one per group.

**`splitGroup` reported stale counts.** It set only the owning side of the relationship, so the response showed the pre-split numbers while the database was correct — which reads exactly like a failed split.

## Theme sweep

The app is light themed, but a lot of markup still assumed the old dark one, leaving translucent panels and light text with nothing dark behind them. Roughly **90 surfaces and 60 text colours** across modals, the manager dashboard, the register page and the skills screens.

Two were invisible rather than merely faint:

- **Skill form inputs** were a 5% white field with white text — invisible typing in an invisible box
- **Notification titles** were white on a `bg-red-50` toast

The unused `.glass-effect` utility is removed so nothing picks it up again. 13 transparent values remain deliberately: hover shimmers at `opacity-0`, dots on solid coloured tabs, an 80% loading scrim, and a 90% label over a photo.

## Verified against a running stack

- 6th player into a 5-player group → 400 with the message the prompt keys on
- Add anyway → 6/5; split → 3/5 and 3/5 with the assessment inherited and no coach
- Bulk move 3 and bulk remove 2 → correct counts, database agrees
- **Atomicity**: a batch with one bad ID → 404 and nobody moved (3 before, 3 after)
- Rejected: player not in source group, empty selection, same source and target, split with a foreign player
- A failed split leaves no group behind
- 6/6 backend tests, 46 migrations on a fresh database, `tsc` and lint clean, production build green, all pages 200

⚠️ **The register page changed the most** — from a dark gradient with glass panels to the light theme matching login. Worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KSHwAZjB9qU97EFgCSh4M