### PR TITLE
Show the scores a read-only assessment actually recorded

### DIFF
--- a/frontend/src/components/assessments/SkillRatingInput.tsx
+++ b/frontend/src/components/assessments/SkillRatingInput.tsx
@@ -36,8 +36,38 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
   };
 
 
-  const currentScore = hoveredScore || value.score;
+  // Hover is a preview of a rating you are about to give, so it must not apply
+  // when the assessment is read-only: hovering a finalized score of 5 would
+  // otherwise display 9/10 and misreport what was actually recorded.
+  const currentScore = (disabled ? 0 : hoveredScore) || value.score;
   const scoreLabel = getScoreLabel(currentScore);
+
+  /**
+   * Fill colour for a filled cell, keyed on the cell's own position, so the
+   * bar runs red -> orange -> yellow -> teal as it fills.
+   *
+   * Kept separate from the disabled state on purpose. Read-only assessments
+   * still need to show which scores were given; disabling only removes the
+   * interactive affordances, never the colour.
+   */
+  const fillClass = (score: number) =>
+    score >= 8
+      ? 'bg-accent-teal'
+      : score >= 6
+        ? 'bg-accent-yellow'
+        : score >= 4
+          ? 'bg-orange-500'
+          : 'bg-accent-red';
+
+  /** Halo on the larger cells, matching the fill. */
+  const ringClass = (score: number) =>
+    score >= 8
+      ? 'ring-2 ring-accent-teal/20'
+      : score >= 6
+        ? 'ring-2 ring-accent-yellow/20'
+        : score >= 4
+          ? 'ring-2 ring-orange-200'
+          : 'ring-2 ring-red-200';
 
   // Initialize if not set
   useEffect(() => {
@@ -91,22 +121,15 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
               type="button"
               disabled={disabled}
               onClick={() => handleScoreChange(score)}
-              onMouseEnter={() => setHoveredScore(score)}
-              onMouseLeave={() => setHoveredScore(0)}
+              onMouseEnter={disabled ? undefined : () => setHoveredScore(score)}
+              onMouseLeave={disabled ? undefined : () => setHoveredScore(0)}
               className={`
                 h-8 w-full rounded text-xs font-semibold transition-all duration-200
                 flex items-center justify-center
-                ${disabled
-                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                  : score <= currentScore
-                    ? score >= 8
-                      ? 'bg-accent-teal text-white hover:bg-accent-teal/90'
-                      : score >= 6
-                        ? 'bg-accent-yellow text-white hover:bg-accent-yellow/90'
-                        : score >= 4
-                          ? 'bg-orange-500 text-white hover:bg-orange-400'
-                          : 'bg-accent-red text-white hover:bg-accent-red/90'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                ${disabled ? 'cursor-not-allowed' : ''}
+                ${score <= currentScore
+                  ? `${fillClass(score)} text-white ${disabled ? '' : 'hover:opacity-90'}`
+                  : `bg-gray-100 ${disabled ? 'text-gray-400' : 'text-gray-600 hover:bg-gray-200'}`
                 }
               `}
             >
@@ -185,22 +208,15 @@ export const SkillRatingInput: React.FC<SkillRatingInputProps> = ({
               type="button"
               disabled={disabled}
               onClick={() => handleScoreChange(score)}
-              onMouseEnter={() => setHoveredScore(score)}
-              onMouseLeave={() => setHoveredScore(0)}
+              onMouseEnter={disabled ? undefined : () => setHoveredScore(score)}
+              onMouseLeave={disabled ? undefined : () => setHoveredScore(0)}
               className={`
                 aspect-square rounded-xl text-sm font-bold transition-all duration-200
                 flex items-center justify-center relative
-                ${disabled
-                  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                  : score <= currentScore
-                    ? score >= 8
-                      ? 'bg-accent-teal text-white shadow-lg hover:shadow-xl transform hover:scale-110 ring-2 ring-accent-teal/20'
-                      : score >= 6
-                        ? 'bg-accent-yellow text-white shadow-lg hover:shadow-xl transform hover:scale-110 ring-2 ring-accent-yellow/20'
-                        : score >= 4
-                          ? 'bg-orange-500 text-white shadow-lg hover:shadow-xl transform hover:scale-110 ring-2 ring-orange-200'
-                          : 'bg-accent-red text-white shadow-lg hover:shadow-xl transform hover:scale-110 ring-2 ring-red-200'
-                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-text-primary transform hover:scale-110'
+                ${disabled ? 'cursor-not-allowed' : 'transform hover:scale-110'}
+                ${score <= currentScore
+                  ? `${fillClass(score)} ${ringClass(score)} text-white shadow-lg ${disabled ? '' : 'hover:shadow-xl'}`
+                  : `bg-gray-100 ${disabled ? 'text-gray-400' : 'text-gray-600 hover:bg-gray-200 hover:text-text-primary'}`
                 }
               `}
             >


### PR DESCRIPTION
## Problem

Opening an old (finalized) assessment on the coach dashboard showed the score heading correctly — `5/10` — above a row of ten uniformly grey cells. None of the recorded scores were highlighted.

## Cause

`SkillRatingInput.tsx` put `disabled` first in the button's class ternary:

```jsx
${disabled
  ? 'bg-gray-100 text-gray-400 cursor-not-allowed'   // always wins
  : score <= currentScore ? ...colour... : ...grey...
```

Viewing an assessment sets `mode='view'` → `isReadOnly` (`AssessmentForm.tsx:68`) → `disabled={true}` (`:524`), so every cell took the grey branch and the colour branch could never run. The heading stayed correct because it does not consult `disabled`.

The scores themselves were always stored correctly — verified against the database, which matched the on-screen numbers exactly.

## Fix

Fill colour now depends only on `score <= currentScore`. `disabled` removes just the interactive affordances (hover, scale, cursor), so a read-only assessment renders identically to an editable one, only inert.

## Second bug fixed alongside

The hover handlers were not guarded by `disabled`, and `currentScore = hoveredScore || value.score`. Hovering over "9" on a finalized assessment scored 5 made the heading display **9/10** — a score that was never given. On a finalized record that misreports the data, so hover is now ignored when read-only.

## Verification

- `npx tsc --noEmit` clean
- Both variants fixed (`compact`, used by the coach form, and full-size)
- Grepped all of `src/` for the same `disabled`-first pattern — appears nowhere else
- Per-colour `ring-2` halo preserved so the editable view is visually unchanged; the compact cells' per-colour `hover:bg-*/90` collapsed to a single `hover:opacity-90` (same result, less duplication)
- Confirmed by the user locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KSHwAZjB9qU97EFgCSh4M