### PR TITLE
Show parents their child's real scores, and fit the screen

### DIFF
--- a/frontend/src/app/parent/assessments/[id]/page.tsx
+++ b/frontend/src/app/parent/assessments/[id]/page.tsx
@@ -5,6 +5,8 @@ import { useParams, useRouter } from "next/navigation";
 import { useAppSelector } from "@/store/hooks";
 import { parentAPI } from "@/lib/api";
 import { SkillRadarChart } from "@/components/player/SkillRadarChart";
+import { getScoreBarColor, scoreToPercent } from "@/types/assessments";
+import { SkillCategory, getCategoryInfo } from "@/types/skills";
 import {
   ArrowLeftIcon,
   UserCircleIcon,
@@ -28,9 +30,14 @@ interface AssessmentResponse {
     id: number;
     skillId: number;
     skillName: string;
-    category: string;
+    // The API sends skillCategory. This was declared as `category`, so every
+    // skill grouped under the key "undefined" and the page rendered a single
+    // card titled "undefined" instead of one per category.
+    skillCategory: string;
     score: number;
     notes?: string;
+    previousScore?: number | null;
+    improvement?: number | null;
   }>;
 }
 
@@ -74,10 +81,10 @@ export default function AssessmentDetailPage() {
 
     const grouped: Record<string, typeof assessment.skillScores> = {};
     assessment.skillScores.forEach((skill) => {
-      if (!grouped[skill.category]) {
-        grouped[skill.category] = [];
+      if (!grouped[skill.skillCategory]) {
+        grouped[skill.skillCategory] = [];
       }
-      grouped[skill.category].push(skill);
+      grouped[skill.skillCategory].push(skill);
     });
     return grouped;
   };
@@ -139,11 +146,13 @@ export default function AssessmentDetailPage() {
 
   const groupedSkills = groupSkillsByCategory(assessment);
 
-  // Transform skills for radar chart (normalize to 0-10 scale)
+  // Scores are already 1-10 (enforced by skill_scores_score_check), and the
+  // radar chart scales them for plotting itself. Dividing here too shrank every
+  // axis to a tenth of its real value.
   const radarSkills = assessment.skillScores?.map(skill => ({
     skillName: skill.skillName,
-    skillCategory: skill.category,
-    score: skill.score / 10, // Normalize from 0-100 to 0-10
+    skillCategory: skill.skillCategory,
+    score: skill.score,
   })) || [];
 
   return (
@@ -158,27 +167,28 @@ export default function AssessmentDetailPage() {
           Back to Assessments
         </button>
 
-        <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
               {assessment.period} Assessment
             </h1>
-            <p className="text-lg text-gray-700 mb-3">
+            <p className="text-base sm:text-lg text-gray-700 mb-3">
               {selectedChild?.firstName} {selectedChild?.lastName}
             </p>
-            <div className="flex items-center gap-6 text-sm text-gray-600">
+            {/* Wraps: on a phone the date and the assessor's name do not fit on one line. */}
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-1 text-sm text-gray-600">
               <span className="flex items-center gap-1">
-                <CalendarIcon className="h-4 w-4" />
+                <CalendarIcon className="h-4 w-4 flex-shrink-0" />
                 {new Date(assessment.assessmentDate).toLocaleDateString()}
               </span>
-              <span className="flex items-center gap-1">
-                <UserIcon className="h-4 w-4" />
-                Assessed by {assessment.assessorName}
+              <span className="flex items-center gap-1 min-w-0">
+                <UserIcon className="h-4 w-4 flex-shrink-0" />
+                <span className="truncate">Assessed by {assessment.assessorName}</span>
               </span>
             </div>
           </div>
 
-          <div className="text-right">
+          <div className="flex items-center justify-between sm:flex-col sm:items-end gap-3 flex-shrink-0">
             <span
               className={`px-3 py-1 rounded-full text-xs font-medium ${
                 assessment.isFinalized
@@ -189,9 +199,9 @@ export default function AssessmentDetailPage() {
               {assessment.isFinalized ? "Finalized" : "Draft"}
             </span>
             {assessment.skillScores && assessment.skillScores.length > 0 && (
-              <div className="mt-3">
+              <div className="text-right">
                 <p className="text-sm text-gray-600">Overall Score</p>
-                <p className="text-3xl font-bold text-gray-900">
+                <p className="text-3xl font-bold text-gray-900 tabular-nums">
                   {getOverallAverage(assessment)}/10
                 </p>
               </div>
@@ -214,11 +224,13 @@ export default function AssessmentDetailPage() {
           {Object.entries(groupedSkills).map(([category, skills]) => (
             <div
               key={category}
-              className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm"
+              className="bg-white rounded-xl p-4 sm:p-6 border border-gray-200 shadow-sm"
             >
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-xl font-semibold text-gray-900">{category}</h3>
-                <span className="text-lg font-bold text-blue-600">
+              <div className="flex items-center justify-between gap-3 mb-4">
+                <h3 className="text-lg sm:text-xl font-semibold text-gray-900 truncate">
+                  {getCategoryInfo(category as SkillCategory)?.label ?? category}
+                </h3>
+                <span className="text-base sm:text-lg font-bold text-blue-600 flex-shrink-0 tabular-nums">
                   Avg: {getCategoryAverage(skills)}/10
                 </span>
               </div>
@@ -226,14 +238,29 @@ export default function AssessmentDetailPage() {
               <div className="space-y-3">
                 {skills?.map((skill) => (
                   <div key={skill.skillId}>
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm text-gray-600">{skill.skillName}</span>
-                      <span className="text-gray-900 font-medium">{(skill.score / 10).toFixed(1)}/10</span>
+                    <div className="flex items-center justify-between gap-3 mb-1">
+                      <span className="text-sm text-gray-600 min-w-0">{skill.skillName}</span>
+                      <span className="flex items-center gap-2 flex-shrink-0">
+                        {/* The API already computes score - previousScore. A parent
+                            wants the direction of travel, not just today's number. */}
+                        {skill.improvement != null && skill.improvement !== 0 && (
+                          <span
+                            className={`text-xs font-semibold ${
+                              skill.improvement > 0 ? "text-accent-teal" : "text-accent-red"
+                            }`}
+                          >
+                            {skill.improvement > 0 ? "↑" : "↓"} {Math.abs(skill.improvement)}
+                          </span>
+                        )}
+                        <span className="text-gray-900 font-semibold tabular-nums">
+                          {skill.score}/10
+                        </span>
+                      </span>
                     </div>
                     <div className="w-full bg-gray-200 rounded-full h-2">
                       <div
-                        className="bg-gradient-to-r from-blue-400 to-cyan-300 h-2 rounded-full transition-all duration-300"
-                        style={{ width: `${skill.score}%` }}
+                        className={`${getScoreBarColor(skill.score)} h-2 rounded-full transition-all duration-300`}
+                        style={{ width: `${scoreToPercent(skill.score)}%` }}
                       />
                     </div>
                     {skill.notes && (

--- a/frontend/src/app/parent/assessments/page.tsx
+++ b/frontend/src/app/parent/assessments/page.tsx
@@ -87,8 +87,8 @@ export default function ParentAssessmentsPage() {
   if (error) {
     return (
       <div className="space-y-6">
-        <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+        <div className="bg-white rounded-xl p-4 sm:p-6 border border-gray-200 shadow-sm">
+          <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
             {selectedChild?.firstName}'s Assessments
           </h1>
           <p className="text-gray-600">Track your child's performance evaluations over time</p>
@@ -117,45 +117,40 @@ export default function ParentAssessmentsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
+      <div className="bg-white rounded-xl p-4 sm:p-6 border border-gray-200 shadow-sm">
+        <h1 className="text-2xl sm:text-3xl font-bold text-gray-900 mb-2">
           {selectedChild?.firstName}'s Assessments
         </h1>
         <p className="text-gray-600">Track your child's performance evaluations over time</p>
       </div>
 
-      {/* Filter Tabs */}
-      <div className="flex gap-2">
-        <button
-          onClick={() => setFilter("all")}
-          className={`px-4 py-2 rounded-lg transition-all ${
-            filter === "all"
-              ? "bg-blue-500 text-white"
-              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-          }`}
-        >
-          All ({assessments.length})
-        </button>
-        <button
-          onClick={() => setFilter("finalized")}
-          className={`px-4 py-2 rounded-lg transition-all ${
-            filter === "finalized"
-              ? "bg-blue-500 text-white"
-              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-          }`}
-        >
-          Finalized ({assessments.filter(a => a.isFinalized).length})
-        </button>
-        <button
-          onClick={() => setFilter("draft")}
-          className={`px-4 py-2 rounded-lg transition-all ${
-            filter === "draft"
-              ? "bg-blue-500 text-white"
-              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-          }`}
-        >
-          Draft ({assessments.filter(a => !a.isFinalized).length})
-        </button>
+      {/* Filter tabs. Wrap rather than run off the side of a phone. */}
+      <div className="flex flex-wrap gap-2">
+        {([
+          { key: "all", label: "All", count: assessments.length },
+          {
+            key: "finalized",
+            label: "Finalised",
+            count: assessments.filter((a) => a.isFinalized).length,
+          },
+          {
+            key: "draft",
+            label: "Draft",
+            count: assessments.filter((a) => !a.isFinalized).length,
+          },
+        ] as const).map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setFilter(tab.key)}
+            className={`px-3 sm:px-4 py-2 text-sm rounded-lg transition-all font-medium ${
+              filter === tab.key
+                ? "bg-blue-500 text-white"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+            }`}
+          >
+            {tab.label} ({tab.count})
+          </button>
+        ))}
       </div>
 
       {/* Assessments List */}
@@ -165,30 +160,32 @@ export default function ParentAssessmentsPage() {
             <Link
               key={assessment.id}
               href={`/parent/assessments/${assessment.id}`}
-              className="bg-white rounded-xl p-6 border border-gray-200 shadow-sm hover:shadow-md transition-all group"
+              className="block bg-white rounded-xl p-4 sm:p-6 border border-gray-200 shadow-sm hover:shadow-md transition-all group"
             >
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-4 mb-3">
-                    <DocumentChartBarIcon className="h-8 w-8 text-text-primary" />
-                    <div>
-                      <h3 className="text-xl font-semibold text-gray-900">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-start gap-3 sm:gap-4 mb-2">
+                    <DocumentChartBarIcon className="h-7 w-7 sm:h-8 sm:w-8 text-text-primary flex-shrink-0 mt-0.5" />
+                    <div className="min-w-0">
+                      <h3 className="text-base sm:text-xl font-semibold text-gray-900 truncate">
                         {assessment.period} Assessment
                       </h3>
-                      <div className="flex items-center gap-4 text-sm text-gray-600">
+                      {/* Date and assessor wrap on narrow screens instead of
+                          pushing the score and chevron off the edge. */}
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 text-xs sm:text-sm text-gray-600">
                         <span className="flex items-center gap-1">
-                          <CalendarIcon className="h-4 w-4" />
+                          <CalendarIcon className="h-4 w-4 flex-shrink-0" />
                           {new Date(assessment.assessmentDate).toLocaleDateString()}
                         </span>
-                        <span>By {assessment.assessorName}</span>
+                        <span className="truncate">By {assessment.assessorName}</span>
                       </div>
                     </div>
                   </div>
 
                   {assessment.skillScores && assessment.skillScores.length > 0 && (
-                    <div className="flex items-center gap-4 mt-3">
-                      <span className="text-sm text-gray-600">Average Score:</span>
-                      <span className="text-2xl font-bold text-gray-900">
+                    <div className="flex items-baseline gap-2 mt-2">
+                      <span className="text-xs sm:text-sm text-gray-600">Average</span>
+                      <span className="text-xl sm:text-2xl font-bold text-gray-900 tabular-nums">
                         {calculateAverageScore(assessment)}/10
                       </span>
                     </div>
@@ -201,13 +198,13 @@ export default function ParentAssessmentsPage() {
                   )}
                 </div>
 
-                <div className="flex items-center gap-3">
-                  <span className={`px-3 py-1 rounded-full text-xs font-medium ${
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <span className={`px-2 sm:px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap ${
                     assessment.isFinalized
                       ? "bg-green-500/20 text-accent-teal"
                       : "bg-yellow-500/20 text-accent-yellow"
                   }`}>
-                    {assessment.isFinalized ? "Finalized" : "Draft"}
+                    {assessment.isFinalized ? "Final" : "Draft"}
                   </span>
                   <ChevronRightIcon className="h-5 w-5 text-text-secondary group-hover:text-gray-600 transition-colors" />
                 </div>

--- a/frontend/src/app/parent/dashboard/page.tsx
+++ b/frontend/src/app/parent/dashboard/page.tsx
@@ -1,26 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useAppSelector } from "@/store/hooks";
-import { AssessmentCard } from "@/components/player/AssessmentCard";
 import { CategoryProgressChart } from "@/components/player/CategoryProgressChart";
 import { SkillProgressChart } from "@/components/player/SkillProgressChart";
 import { parentAPI } from "@/lib/api";
-import { ResponsiveHeader, ResponsiveGrid, ResponsiveCard, ResponsiveButtonGroup } from "@/components/responsive";
-
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api";
+import {
+  getScoreBarColor,
+  getScoreLabel,
+  scoreToPercent,
+  type Assessment,
+  type SkillScore,
+} from "@/types/assessments";
+import { SkillCategory, getCategoryInfo } from "@/types/skills";
 import {
   UserCircleIcon,
   CalendarIcon,
-  TrophyIcon,
   ChartBarIcon,
+  ChatBubbleLeftRightIcon,
   ArrowTrendingUpIcon,
-  AcademicCapIcon,
 } from "@heroicons/react/24/outline";
-import { AppDispatch, RootState } from "@/store";
-import type { Assessment } from "@/types/assessments";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api";
 
 interface ChildProfile {
   id: number;
@@ -32,35 +34,25 @@ interface ChildProfile {
   joiningDate: string;
 }
 
+/** How many skills to call out as strengths, and as things to work on. */
+const HIGHLIGHT_COUNT = 3;
+
 export default function ParentDashboard() {
-  const user = useAppSelector((state) => state.auth.user);
   const selectedChildId = useAppSelector((state) => state.auth.selectedChildId);
-  const dispatch = useDispatch<AppDispatch>();
 
   const [childProfile, setChildProfile] = useState<ChildProfile | null>(null);
   const [assessments, setAssessments] = useState<Assessment[]>([]);
   const [loading, setLoading] = useState(true);
-  const [assessmentLoading, setAssessmentLoading] = useState(false);
   const [selectedSkill, setSelectedSkill] = useState<{ name: string; category: string } | null>(null);
   const [viewMode, setViewMode] = useState<"overview" | "skills">("overview");
 
-  // Fetch child data when selectedChildId changes
-  useEffect(() => {
-    if (selectedChildId) {
-      fetchChildData();
-    }
-  }, [selectedChildId]);
-
-  const fetchChildData = async () => {
+  const fetchChildData = useCallback(async () => {
     if (!selectedChildId) return;
 
     try {
       setLoading(true);
-      setAssessmentLoading(true);
-
       const token = localStorage.getItem("jwt_token");
 
-      // Fetch child profile
       const profileResponse = await fetch(
         `${API_BASE_URL}/parents/me/children/${selectedChildId}`,
         {
@@ -72,376 +64,537 @@ export default function ParentDashboard() {
       );
 
       if (profileResponse.ok) {
-        const profileData = await profileResponse.json();
-        setChildProfile(profileData);
+        setChildProfile(await profileResponse.json());
       }
 
-      // Fetch child assessments using parentAPI
       const assessmentData = await parentAPI.getChildAssessments(selectedChildId);
       setAssessments(assessmentData as Assessment[]);
     } catch (error) {
       console.error("Error fetching child data:", error);
     } finally {
       setLoading(false);
-      setAssessmentLoading(false);
     }
+  }, [selectedChildId]);
+
+  useEffect(() => {
+    fetchChildData();
+  }, [fetchChildData]);
+
+  const latest: Assessment | null = assessments.length > 0 ? assessments[0] : null;
+  const previous: Assessment | null = assessments.length > 1 ? assessments[1] : null;
+
+  const averageOf = (assessment: Assessment | null): number | null => {
+    if (!assessment) return null;
+    if (typeof assessment.overallAverage === "number") return assessment.overallAverage;
+    const scores = assessment.skillScores ?? [];
+    if (scores.length === 0) return null;
+    return scores.reduce((sum, s) => sum + s.score, 0) / scores.length;
   };
 
-  // Get all unique skills from assessments for selection
-  const availableSkills = Array.from(
-    new Set(
-      assessments
-        .flatMap((a) => a.skillScores || [])
-        .map((skill) => `${skill.skillName}|${skill.skillCategory}`)
-    )
-  )
-    .map((skillStr) => {
-      const [name, category] = skillStr.split("|");
-      return { name, category };
+  const currentAverage = averageOf(latest);
+  const previousAverage = averageOf(previous);
+  const change =
+    currentAverage != null && previousAverage != null ? currentAverage - previousAverage : null;
+
+  const latestScores: SkillScore[] = latest?.skillScores ?? [];
+
+  // Sorted once, read from both ends: the top few are what to celebrate, the
+  // bottom few are what to practise. Ties broken by name so the order is stable
+  // between renders rather than shuffling on every fetch.
+  const ranked = [...latestScores].sort(
+    (a, b) => b.score - a.score || a.skillName.localeCompare(b.skillName)
+  );
+  const strengths = ranked.slice(0, HIGHLIGHT_COUNT);
+  const focusAreas = ranked.slice(-HIGHLIGHT_COUNT).reverse();
+
+  const categoryAverages = Object.values(SkillCategory)
+    .map((category) => {
+      const inCategory = latestScores.filter((s) => s.skillCategory === category);
+      if (inCategory.length === 0) return null;
+      return {
+        category,
+        average: inCategory.reduce((sum, s) => sum + s.score, 0) / inCategory.length,
+        count: inCategory.length,
+      };
     })
-    .sort((a, b) => `${a.category}-${a.name}`.localeCompare(`${b.category}-${b.name}`));
+    .filter((c): c is { category: SkillCategory; average: number; count: number } => c !== null);
 
-  const getProgressStats = () => {
-    if (assessments.length < 2) return null;
+  /**
+   * Every skill this child has ever been scored on, with its latest score and
+   * how much it moved since the assessment before.
+   *
+   * Grouped by category so the picker can use optgroups, which is what lets a
+   * single compact control stand in for what used to be a list of one tall
+   * card per skill.
+   */
+  const skillOptions = (() => {
+    const byKey = new Map<
+      string,
+      { name: string; category: string; latest: number | null; change: number | null }
+    >();
 
-    const latest = assessments[0];
-    const previous = assessments[1];
+    // assessments is newest first, so the first score seen for a skill is its
+    // current one and the second is what to compare against.
+    assessments.forEach((assessment) => {
+      (assessment.skillScores || []).forEach((s) => {
+        const key = `${s.skillCategory}|${s.skillName}`;
+        const existing = byKey.get(key);
+        if (!existing) {
+          byKey.set(key, {
+            name: s.skillName,
+            category: s.skillCategory,
+            latest: s.score,
+            change: null,
+          });
+        } else if (existing.change === null && existing.latest !== null) {
+          existing.change = existing.latest - s.score;
+        }
+      });
+    });
 
-    if (!latest.skillScores || !previous.skillScores) return null;
+    return Array.from(byKey.values()).sort(
+      (a, b) => a.category.localeCompare(b.category) || a.name.localeCompare(b.name)
+    );
+  })();
 
-    const latestAvg =
-      latest.skillScores.reduce((sum, skill) => sum + skill.score, 0) / latest.skillScores.length;
-    const previousAvg =
-      previous.skillScores.reduce((sum, skill) => sum + skill.score, 0) /
-      previous.skillScores.length;
+  const skillCategoriesPresent = Array.from(new Set(skillOptions.map((s) => s.category)));
 
-    return {
-      current: latestAvg,
-      change: latestAvg - previousAvg,
-      assessmentCount: assessments.length,
-      latestDate: new Date(latest.assessmentDate).toLocaleDateString(),
-    };
-  };
+  // Open on whatever moved most: with nothing selected the chart area was dead
+  // space, and the biggest mover is the thing a parent would look up first.
+  const defaultSkill =
+    skillOptions.length === 0
+      ? null
+      : [...skillOptions].sort(
+          (a, b) => Math.abs(b.change ?? 0) - Math.abs(a.change ?? 0) || a.name.localeCompare(b.name)
+        )[0];
 
-  const stats = getProgressStats();
-  const latestAssessment = assessments.length > 0 ? assessments[0] : null;
+  const activeSkill = selectedSkill ?? defaultSkill;
+
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
 
   if (!selectedChildId) {
     return (
-      <div className="space-y-6">
-        <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-lg text-center">
-          <UserCircleIcon className="h-16 w-16 text-primary mx-auto mb-4" />
-          <h3 className="text-xl font-bold text-text-primary mb-3">No Child Selected</h3>
-          <p className="text-text-secondary text-base">
-            Please select a child from the sidebar to view their performance data.
-          </p>
-        </div>
+      <div className="bg-white rounded-2xl p-6 sm:p-8 border border-gray-100 shadow-lg text-center">
+        <UserCircleIcon className="h-12 w-12 text-primary mx-auto mb-4" />
+        <h3 className="text-lg sm:text-xl font-bold text-text-primary mb-2">No child selected</h3>
+        <p className="text-text-secondary text-sm sm:text-base">
+          Choose a child from the menu to see how they are getting on.
+        </p>
       </div>
     );
   }
 
-  if (loading || assessmentLoading) {
+  if (loading) {
     return (
-      <div className="space-y-6">
-        <div className="flex items-center justify-center min-h-[400px]">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary"></div>
-        </div>
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
       </div>
     );
   }
+
+  const childName = childProfile?.firstName ?? "Your child";
 
   return (
-    <div className="space-y-6 sm:space-y-8">
-      {/* Welcome Section with Progress Summary */}
-      <div className="bg-gradient-to-r from-primary/5 via-white to-accent-teal/5 rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <h1 className="text-xl sm:text-2xl font-bold text-text-primary mb-2">
-              {childProfile?.firstName}'s Progress Dashboard
+    <div className="space-y-4 sm:space-y-6">
+      {/*
+        The headline: how is my child doing right now. Everything else on this
+        page is a supporting detail, and is sized accordingly.
+      */}
+      <section className="bg-gradient-to-br from-primary/5 via-white to-accent-teal/5 rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-4 sm:gap-6">
+          <div className="min-w-0 flex-1">
+            <h1 className="text-xl sm:text-2xl font-bold text-text-primary">
+              {childName}&apos;s progress
             </h1>
-            <p className="text-sm sm:text-base text-text-secondary">
-              Track your child's progress and view their performance assessments
-            </p>
+            {latest ? (
+              <p className="text-sm text-text-secondary mt-1">
+                Last assessed {formatDate(latest.assessmentDate)}
+                {latest.assessorName ? ` by ${latest.assessorName}` : ""}
+              </p>
+            ) : (
+              <p className="text-sm text-text-secondary mt-1">No assessments yet</p>
+            )}
           </div>
 
-          {stats && (
-            <div className="bg-white rounded-xl p-4 shadow-lg border border-gray-200 flex-shrink-0 w-full sm:w-auto">
-              <div className="text-center">
-                <div className="text-2xl sm:text-3xl font-bold text-primary mb-2">
-                  {stats.current.toFixed(1)}/10
-                </div>
+          {currentAverage != null && (
+            <div className="bg-white rounded-xl px-5 py-4 shadow-md border border-gray-200 flex-shrink-0 w-full sm:w-auto text-center">
+              <div className="text-4xl sm:text-5xl font-bold text-text-primary tabular-nums leading-none">
+                {currentAverage.toFixed(1)}
+                <span className="text-xl sm:text-2xl text-text-secondary font-semibold">/10</span>
+              </div>
+              <div className="text-sm font-semibold text-text-primary mt-2">
+                {getScoreLabel(currentAverage)}
+              </div>
+              {change != null && (
                 <div
-                  className={`text-sm font-medium mb-1 ${
-                    stats.change >= 0 ? "text-accent-teal" : "text-accent-red"
+                  className={`text-xs font-medium mt-1 ${
+                    change >= 0 ? "text-accent-teal" : "text-accent-red"
                   }`}
                 >
-                  {stats.change >= 0 ? "↑" : "↓"} {Math.abs(stats.change).toFixed(1)} from last
-                  assessment
+                  {change >= 0 ? "↑" : "↓"} {Math.abs(change).toFixed(1)} since last time
                 </div>
-                <div className="text-xs text-text-secondary">Latest: {stats.latestDate}</div>
-              </div>
+              )}
             </div>
           )}
         </div>
-      </div>
+      </section>
 
-      {/* Quick Stats */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-        <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-5 border border-gray-100 shadow-lg hover:shadow-xl transition-all">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-primary/10 rounded-full flex-shrink-0">
-              <AcademicCapIcon className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs sm:text-sm font-medium text-text-secondary">Level</p>
-              <p className="text-lg sm:text-xl font-bold text-text-primary truncate">
-                {childProfile?.level || "N/A"}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-5 border border-gray-100 shadow-lg hover:shadow-xl transition-all">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-accent-yellow/10 rounded-full flex-shrink-0">
-              <TrophyIcon className="h-5 w-5 sm:h-6 sm:w-6 text-accent-yellow" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs sm:text-sm font-medium text-text-secondary">Group</p>
-              <p className="text-lg sm:text-xl font-bold text-text-primary truncate">
-                {childProfile?.groupName || "Unassigned"}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-5 border border-gray-100 shadow-lg hover:shadow-xl transition-all">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-accent-teal/10 rounded-full flex-shrink-0">
-              <CalendarIcon className="h-5 w-5 sm:h-6 sm:w-6 text-accent-teal" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs sm:text-sm font-medium text-text-secondary">Member Since</p>
-              <p className="text-base sm:text-lg font-bold text-text-primary truncate">
-                {childProfile?.joiningDate
-                  ? new Date(childProfile.joiningDate).toLocaleDateString("en-US", {
-                      month: "short",
-                      year: "numeric",
-                    })
-                  : "N/A"}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-xl sm:rounded-2xl p-4 sm:p-5 border border-gray-100 shadow-lg hover:shadow-xl transition-all">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-secondary/10 rounded-full flex-shrink-0">
-              <ChartBarIcon className="h-5 w-5 sm:h-6 sm:w-6 text-secondary" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs sm:text-sm font-medium text-text-secondary">Assessments</p>
-              <p className="text-lg sm:text-xl font-bold text-text-primary">{assessments.length}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Progress Analytics Section */}
-      {assessments.length >= 2 ? (
-        <div className="space-y-4">
-          {/* Progress Analytics Header */}
-          <div className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
-              <div className="flex-1 min-w-0">
-                <h2 className="text-lg sm:text-xl font-bold text-text-primary mb-1">Progress Analytics</h2>
-                <p className="text-xs sm:text-sm text-text-secondary">
-                  Track your child's skill development and performance trends over time
-                </p>
-              </div>
-
-              {/* View Mode Toggle */}
-              <div className="flex gap-2 w-full sm:w-auto">
-                <button
-                  onClick={() => setViewMode("overview")}
-                  className={`flex-1 sm:flex-none px-3 py-2 text-xs sm:text-sm rounded-lg transition-all font-medium ${
-                    viewMode === "overview"
-                      ? "bg-primary text-white shadow-lg"
-                      : "bg-secondary-100 text-text-primary hover:bg-secondary-50"
-                  }`}
-                >
-                  <span className="hidden sm:inline">Category Overview</span>
-                  <span className="sm:hidden">Overview</span>
-                </button>
-                <button
-                  onClick={() => setViewMode("skills")}
-                  className={`flex-1 sm:flex-none px-3 py-2 text-xs sm:text-sm rounded-lg transition-all font-medium ${
-                    viewMode === "skills"
-                      ? "bg-primary text-white shadow-lg"
-                      : "bg-secondary-100 text-text-primary hover:bg-secondary-50"
-                  }`}
-                >
-                  <span className="hidden sm:inline">Individual Skills</span>
-                  <span className="sm:hidden">Skills</span>
-                </button>
-              </div>
-            </div>
-
-            {/* Overview Mode */}
-            {viewMode === "overview" && <CategoryProgressChart assessments={assessments} />}
-
-            {/* Skills Mode */}
-            {viewMode === "skills" && (
-              <div className="space-y-4">
-                {/* Skill Selector */}
-                <div>
-                  <h3 className="text-sm sm:text-base font-semibold text-text-primary mb-3">
-                    Select a Skill to View Progress
-                  </h3>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                    {availableSkills.map((skill) => (
-                      <button
-                        key={`${skill.category}-${skill.name}`}
-                        onClick={() => setSelectedSkill(skill)}
-                        className={`p-3 rounded-xl text-left transition-all ${
-                          selectedSkill?.name === skill.name &&
-                          selectedSkill?.category === skill.category
-                            ? "bg-primary text-white shadow-lg"
-                            : "bg-secondary-50 text-text-primary hover:bg-secondary-100 hover:shadow-md"
-                        }`}
-                      >
-                        <div className="text-sm font-medium">{skill.name}</div>
-                        <div className="text-xs opacity-70">{skill.category}</div>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Selected Skill Progress */}
-                {selectedSkill && (
-                  <SkillProgressChart
-                    assessments={assessments}
-                    skillName={selectedSkill.name}
-                    category={selectedSkill.category}
-                  />
-                )}
-
-                {!selectedSkill && (
-                  <div className="bg-secondary-50 rounded-xl p-8 text-center">
-                    <ChartBarIcon className="h-12 w-12 text-text-primary mx-auto mb-3" />
-                    <p className="text-text-secondary text-base">
-                      Select a skill above to view its progress over time
-                    </p>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-      ) : assessments.length === 1 ? (
-        <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-lg text-center">
-          <ArrowTrendingUpIcon className="h-16 w-16 text-accent-yellow mx-auto mb-4" />
-          <h3 className="text-xl font-bold text-text-primary mb-3">Need More Data</h3>
-          <p className="text-text-secondary text-base">
-            Your child needs at least 2 assessments to see progress trends and analytics.
+      {!latest ? (
+        <div className="bg-white rounded-2xl p-6 sm:p-8 border border-gray-100 shadow-lg text-center">
+          <ChartBarIcon className="h-12 w-12 text-primary mx-auto mb-4" />
+          <h3 className="text-lg sm:text-xl font-bold text-text-primary mb-2">
+            No assessment yet
+          </h3>
+          <p className="text-text-secondary text-sm sm:text-base">
+            {childName} hasn&apos;t had their first assessment. Once a coach completes one, their
+            scores and progress will appear here.
           </p>
         </div>
       ) : (
-        <div className="bg-white rounded-2xl p-8 border border-gray-100 shadow-lg text-center">
-          <ChartBarIcon className="h-16 w-16 text-primary mx-auto mb-4" />
-          <h3 className="text-xl font-bold text-text-primary mb-3">No Progress Data</h3>
-          <p className="text-text-secondary text-base mb-4">
-            Your child hasn't completed their first assessment yet.
-          </p>
-        </div>
-      )}
+        <>
+          {/*
+            The most actionable thing a parent can take away: what is going
+            well, and what to practise before the next assessment.
+          */}
+          {latestScores.length > 0 && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <HighlightCard
+                title="Doing well"
+                tone="positive"
+                skills={strengths}
+                emptyLabel="No scores recorded"
+              />
+              <HighlightCard
+                title="Worth practising"
+                tone="attention"
+                skills={focusAreas}
+                emptyLabel="No scores recorded"
+              />
+            </div>
+          )}
 
-      {/* Latest Assessment Section */}
-      {latestAssessment && (
-        <div className="bg-white rounded-2xl p-6 border border-gray-100 shadow-lg">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-bold text-text-primary">Latest Assessment</h2>
+          {/* Four numbers a parent can hold in their head. */}
+          {categoryAverages.length > 0 && (
+            <section className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+              <h2 className="text-base sm:text-lg font-bold text-text-primary mb-4">
+                How {childName} scored in each area
+              </h2>
+              <div className="space-y-4">
+                {categoryAverages.map(({ category, average, count }) => {
+                  const info = getCategoryInfo(category);
+                  return (
+                    <div key={category}>
+                      <div className="flex items-center justify-between gap-3 mb-1.5">
+                        <span className="text-sm font-medium text-text-primary min-w-0 truncate">
+                          <span aria-hidden="true">{info?.icon} </span>
+                          {info?.label ?? category}
+                          <span className="text-text-secondary font-normal">
+                            {" "}
+                            ({count} skill{count === 1 ? "" : "s"})
+                          </span>
+                        </span>
+                        <span className="text-sm font-bold text-text-primary flex-shrink-0 tabular-nums">
+                          {average.toFixed(1)}/10
+                        </span>
+                      </div>
+                      <div className="w-full bg-gray-200 rounded-full h-2.5">
+                        <div
+                          className={`${getScoreBarColor(average)} h-2.5 rounded-full transition-all duration-300`}
+                          style={{ width: `${scoreToPercent(average)}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* What the coach actually said, rather than only numbers. */}
+          {(latest.comments || latest.coachNotes) && (
+            <section className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+              <div className="flex items-center gap-2 mb-3">
+                <ChatBubbleLeftRightIcon className="h-5 w-5 text-primary flex-shrink-0" />
+                <h2 className="text-base sm:text-lg font-bold text-text-primary">
+                  From the coach
+                </h2>
+              </div>
+              {latest.comments && (
+                <p className="text-sm sm:text-base text-text-primary whitespace-pre-line">
+                  {latest.comments}
+                </p>
+              )}
+              {latest.coachNotes && (
+                <p className="text-sm sm:text-base text-text-primary whitespace-pre-line mt-3">
+                  {latest.coachNotes}
+                </p>
+              )}
+            </section>
+          )}
+
+          <div className="flex">
             <Link
-              href={`/parent/assessments/${latestAssessment.id}`}
-              className="flex items-center gap-2 px-3 py-2 text-sm bg-primary hover:bg-primary-hover text-white rounded-lg transition-colors font-medium"
+              href={`/parent/assessments/${latest.id}`}
+              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-5 py-3 bg-primary hover:bg-primary-hover text-white rounded-xl transition-colors font-semibold"
             >
-              View Details
+              See the full assessment
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
             </Link>
           </div>
-          <AssessmentCard assessment={latestAssessment} />
-        </div>
-      )}
 
-      {/* Assessment History */}
-      {assessments.length > 0 && (
-        <div className="bg-white rounded-2xl p-4 border border-gray-100 shadow-lg">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-text-primary">Recent Assessment History</h3>
-            <Link
-              href="/parent/assessments"
-              className="text-sm text-primary hover:text-primary-hover transition-colors font-medium"
-            >
-              View All →
-            </Link>
-          </div>
-          <div className="space-y-3">
-            {assessments.slice(0, 5).map((assessment, index) => (
-              <div
-                key={assessment.id}
-                className="flex items-center justify-between p-3 bg-secondary-50 rounded-xl hover:bg-secondary-100 transition-colors"
-              >
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-white rounded-lg shadow-sm">
-                    <CalendarIcon className="h-4 w-4 text-primary" />
-                  </div>
-                  <div>
-                    <div className="text-sm font-semibold text-text-primary">
-                      {assessment.period}
-                    </div>
-                    <div className="text-xs text-text-secondary">
-                      {new Date(assessment.assessmentDate).toLocaleDateString("en-US", {
-                        month: "long",
-                        day: "numeric",
-                        year: "numeric",
-                      })}
-                    </div>
-                  </div>
+          {/* Trends need at least two assessments to mean anything. */}
+          {assessments.length >= 2 ? (
+            <section className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+                <div className="min-w-0">
+                  <h2 className="text-base sm:text-lg font-bold text-text-primary">
+                    Progress over time
+                  </h2>
+                  <p className="text-xs sm:text-sm text-text-secondary">
+                    Across {assessments.length} assessments
+                  </p>
                 </div>
-                <div className="flex items-center gap-3">
-                  <div className="text-right">
-                    <div className="text-xl font-bold text-text-primary">
-                      {assessment.skillScores
-                        ? (
-                            assessment.skillScores.reduce((sum, skill) => sum + skill.score, 0) /
-                            assessment.skillScores.length
-                          ).toFixed(1)
-                        : "N/A"}
-                      /10
-                    </div>
-                  </div>
-                  <span
-                    className={`px-2 py-1 rounded-full text-xs font-medium ${
-                      assessment.isFinalized
-                        ? "bg-accent-teal/20 text-accent-teal"
-                        : "bg-accent-yellow/20 text-accent-yellow"
+                <div className="flex gap-2 w-full sm:w-auto">
+                  <button
+                    onClick={() => setViewMode("overview")}
+                    className={`flex-1 sm:flex-none px-3 py-2 text-xs sm:text-sm rounded-lg transition-all font-medium ${
+                      viewMode === "overview"
+                        ? "bg-primary text-white shadow"
+                        : "bg-secondary-100 text-text-primary hover:bg-secondary-50"
                     }`}
                   >
-                    {assessment.isFinalized ? "Final" : "Draft"}
-                  </span>
+                    By area
+                  </button>
+                  <button
+                    onClick={() => setViewMode("skills")}
+                    className={`flex-1 sm:flex-none px-3 py-2 text-xs sm:text-sm rounded-lg transition-all font-medium ${
+                      viewMode === "skills"
+                        ? "bg-primary text-white shadow"
+                        : "bg-secondary-100 text-text-primary hover:bg-secondary-50"
+                    }`}
+                  >
+                    By skill
+                  </button>
                 </div>
               </div>
-            ))}
-          </div>
-        </div>
+
+              {viewMode === "overview" && <CategoryProgressChart assessments={assessments} />}
+
+              {viewMode === "skills" && (
+                <div className="space-y-4">
+                  <div>
+                    <label
+                      htmlFor="skill-picker"
+                      className="block text-sm font-semibold text-text-primary mb-2"
+                    >
+                      Pick a skill to see how it has changed
+                    </label>
+                    {/*
+                      One compact control rather than a card per skill. With 27
+                      skills the old list was 27 full-width rows to scroll past
+                      before the chart came into view on a phone, and it repeated
+                      the category on every single row.
+                    */}
+                    <select
+                      id="skill-picker"
+                      className="select-base w-full"
+                      value={activeSkill ? `${activeSkill.category}|${activeSkill.name}` : ""}
+                      onChange={(e) => {
+                        const [category, name] = e.target.value.split("|");
+                        setSelectedSkill({ name, category });
+                      }}
+                    >
+                      {skillCategoriesPresent.map((category) => (
+                        <optgroup
+                          key={category}
+                          label={
+                            getCategoryInfo(category as SkillCategory)?.label ?? category
+                          }
+                        >
+                          {skillOptions
+                            .filter((s) => s.category === category)
+                            .map((s) => (
+                              <option key={`${s.category}|${s.name}`} value={`${s.category}|${s.name}`}>
+                                {s.name}
+                                {s.latest != null ? ` — ${s.latest}/10` : ""}
+                                {s.change ? ` (${s.change > 0 ? "+" : ""}${s.change})` : ""}
+                              </option>
+                            ))}
+                        </optgroup>
+                      ))}
+                    </select>
+                  </div>
+
+                  {activeSkill && (
+                    <SkillProgressChart
+                      assessments={assessments}
+                      skillName={activeSkill.name}
+                      category={activeSkill.category}
+                    />
+                  )}
+                </div>
+              )}
+            </section>
+          ) : (
+            <section className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+              <div className="flex items-start gap-3">
+                <ArrowTrendingUpIcon className="h-5 w-5 text-accent-yellow flex-shrink-0 mt-0.5" />
+                <div className="min-w-0">
+                  <h2 className="text-base font-bold text-text-primary">Progress over time</h2>
+                  <p className="text-sm text-text-secondary mt-1">
+                    After a second assessment you&apos;ll be able to see how {childName} is
+                    improving over time.
+                  </p>
+                </div>
+              </div>
+            </section>
+          )}
+
+          {/* History, most recent first. */}
+          <section className="bg-white rounded-2xl p-4 sm:p-6 border border-gray-100 shadow-lg">
+            <div className="flex items-center justify-between gap-3 mb-3">
+              <h2 className="text-base sm:text-lg font-bold text-text-primary">
+                Past assessments
+              </h2>
+              {assessments.length > 5 && (
+                <Link
+                  href="/parent/assessments"
+                  className="text-sm text-primary hover:text-primary-hover font-medium flex-shrink-0"
+                >
+                  View all
+                </Link>
+              )}
+            </div>
+            <div className="space-y-2">
+              {assessments.slice(0, 5).map((assessment) => {
+                const average = averageOf(assessment);
+                return (
+                  <Link
+                    key={assessment.id}
+                    href={`/parent/assessments/${assessment.id}`}
+                    className="flex items-center justify-between gap-3 p-3 bg-secondary-50 rounded-xl hover:bg-secondary-100 transition-colors"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <CalendarIcon className="h-4 w-4 text-primary flex-shrink-0" />
+                      <div className="min-w-0">
+                        <div className="text-sm font-semibold text-text-primary truncate">
+                          {assessment.period}
+                        </div>
+                        <div className="text-xs text-text-secondary">
+                          {formatDate(assessment.assessmentDate)}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="text-base font-bold text-text-primary flex-shrink-0 tabular-nums">
+                      {average != null ? `${average.toFixed(1)}/10` : "—"}
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        </>
       )}
+
+      {/*
+        Administrative detail. Real, but not what a parent opens this page for,
+        so it sits at the bottom in one quiet row instead of four large tiles.
+      */}
+      <section className="bg-white rounded-2xl p-4 border border-gray-100 shadow-sm">
+        <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
+          <MetaItem label="Level" value={childProfile?.level ?? "—"} />
+          <MetaItem label="Group" value={childProfile?.groupName ?? "Unassigned"} />
+          <MetaItem
+            label="Member since"
+            value={
+              childProfile?.joiningDate
+                ? new Date(childProfile.joiningDate).toLocaleDateString("en-GB", {
+                    month: "short",
+                    year: "numeric",
+                  })
+                : "—"
+            }
+          />
+          <MetaItem label="Assessments" value={String(assessments.length)} />
+        </dl>
+      </section>
     </div>
+  );
+}
+
+function MetaItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs text-text-secondary">{label}</dt>
+      <dd className="text-sm font-semibold text-text-primary truncate">{value}</dd>
+    </div>
+  );
+}
+
+function HighlightCard({
+  title,
+  tone,
+  skills,
+  emptyLabel,
+}: {
+  title: string;
+  tone: "positive" | "attention";
+  skills: SkillScore[];
+  emptyLabel: string;
+}) {
+  return (
+    <section className="bg-white rounded-2xl p-4 sm:p-5 border border-gray-100 shadow-lg">
+      <h2 className="text-base font-bold text-text-primary mb-3">
+        <span
+          className={`inline-block w-2 h-2 rounded-full mr-2 align-middle ${
+            tone === "positive" ? "bg-accent-teal" : "bg-orange-500"
+          }`}
+          aria-hidden="true"
+        />
+        {title}
+      </h2>
+      {skills.length === 0 ? (
+        <p className="text-sm text-text-secondary">{emptyLabel}</p>
+      ) : (
+        <ul className="space-y-2.5">
+          {skills.map((skill) => (
+            <li key={skill.skillId}>
+              <div className="flex items-center justify-between gap-3 mb-1">
+                <span className="text-sm text-text-primary min-w-0 truncate">
+                  {skill.skillName}
+                </span>
+                <span className="flex items-center gap-2 flex-shrink-0">
+                  {skill.improvement != null && skill.improvement !== 0 && (
+                    <span
+                      className={`text-xs font-semibold ${
+                        skill.improvement > 0 ? "text-accent-teal" : "text-accent-red"
+                      }`}
+                    >
+                      {skill.improvement > 0 ? "↑" : "↓"} {Math.abs(skill.improvement)}
+                    </span>
+                  )}
+                  <span className="text-sm font-bold text-text-primary tabular-nums">
+                    {skill.score}/10
+                  </span>
+                </span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-1.5">
+                <div
+                  className={`${getScoreBarColor(skill.score)} h-1.5 rounded-full`}
+                  style={{ width: `${scoreToPercent(skill.score)}%` }}
+                />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/frontend/src/app/parent/nutrition/page.tsx
+++ b/frontend/src/app/parent/nutrition/page.tsx
@@ -102,33 +102,37 @@ export default function ParentNutritionPage() {
       )}
 
       {/* Hero Section */}
-      <div className="bg-gradient-to-r from-accent-teal/10 via-white to-accent-yellow/10 rounded-2xl p-8 border border-gray-100 shadow-lg">
-        <div className="flex items-start justify-between gap-6">
-          <div className="flex-1">
+      <div className="bg-gradient-to-r from-accent-teal/10 via-white to-accent-yellow/10 rounded-2xl p-4 sm:p-8 border border-gray-100 shadow-lg">
+        {/*
+          Stacks on a phone. Side by side, the heading block took flex-1 and
+          squeezed the download button off the edge of the screen.
+        */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 sm:gap-6">
+          <div className="flex-1 min-w-0">
             <div className="flex items-center gap-3 mb-3">
-              <div className="w-12 h-12 bg-accent-teal/10 rounded-xl flex items-center justify-center">
-                <DocumentTextIcon className="w-6 h-6 text-accent-teal" />
+              <div className="w-10 h-10 sm:w-12 sm:h-12 bg-accent-teal/10 rounded-xl flex items-center justify-center flex-shrink-0">
+                <DocumentTextIcon className="w-5 h-5 sm:w-6 sm:h-6 text-accent-teal" />
               </div>
-              <div>
-                <h1 className="text-3xl font-bold text-text-primary">
+              <div className="min-w-0">
+                <h1 className="text-xl sm:text-3xl font-bold text-text-primary">
                   Nutrition Meal Plan
                 </h1>
-                <p className="text-sm text-text-secondary">
+                <p className="text-xs sm:text-sm text-text-secondary truncate">
                   For {selectedChild.firstName} {selectedChild.lastName} ({age}{" "}
                   years old)
                 </p>
               </div>
             </div>
 
-            <p className="text-text-secondary mb-4">
+            <p className="text-sm sm:text-base text-text-secondary mb-4">
               Personalized nutrition guidance designed to fuel young athletes
               and support their development, energy levels, and performance on
               and off the field.
             </p>
 
-            <div className="flex items-center gap-3">
-              <span className="inline-flex items-center gap-2 px-4 py-2 bg-accent-teal/10 text-accent-teal rounded-lg text-sm font-medium">
-                <SparklesIcon className="w-4 h-4" />
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              <span className="inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-accent-teal/10 text-accent-teal rounded-lg text-sm font-medium">
+                <SparklesIcon className="w-4 h-4 flex-shrink-0" />
                 {mealPlan.ageRange} Age Group
               </span>
               {age > 12 && (
@@ -139,12 +143,12 @@ export default function ParentNutritionPage() {
             </div>
           </div>
 
-          {/* Download Button */}
+          {/* Full width on a phone so it is a comfortable tap target. */}
           <button
             onClick={handleDownload}
-            className="btn-primary flex items-center gap-2 shadow-lg hover:shadow-xl transition-all"
+            className="btn-primary flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transition-all w-full sm:w-auto flex-shrink-0 whitespace-nowrap"
           >
-            <DocumentArrowDownIcon className="w-5 h-5" />
+            <DocumentArrowDownIcon className="w-5 h-5 flex-shrink-0" />
             Download PDF
           </button>
         </div>
@@ -164,24 +168,28 @@ export default function ParentNutritionPage() {
 
         {/* PDF Viewer - Using embed for better default zoom */}
         <div className="relative bg-gray-50 rounded-lg">
+          {/*
+            Height scales with the viewport instead of a fixed 1400px, which on
+            a phone was several screens of scrolling before anything else on the
+            page could be reached.
+          */}
           <embed
             src={`${pdfPath}#zoom=150`}
             type="application/pdf"
-            className={`w-full rounded-lg ${isPdfLoading ? "hidden" : "block"}`}
-            style={{
-              height: "1400px",
-              minHeight: "1200px",
-            }}
+            className={`w-full rounded-lg h-[70vh] sm:h-[900px] lg:h-[1400px] ${
+              isPdfLoading ? "hidden" : "block"
+            }`}
             onLoad={() => setIsPdfLoading(false)}
           />
 
           {/* PDF Controls Bar */}
           {!isPdfLoading && (
-            <div className="absolute top-2 left-2 right-2 flex justify-between items-center bg-white/90 backdrop-blur-sm rounded-lg p-2 shadow-sm">
-              <div className="text-xs text-gray-600 font-medium">
+            <div className="absolute top-2 left-2 right-2 flex justify-end sm:justify-between items-center gap-2 bg-white/90 backdrop-blur-sm rounded-lg p-2 shadow-sm">
+              {/* The name is context, not a control: it yields first when space is tight. */}
+              <div className="hidden sm:block text-xs text-gray-600 font-medium truncate min-w-0">
                 Meal Plan - {selectedChild.firstName} {selectedChild.lastName}
               </div>
-              <div className="flex gap-2">
+              <div className="flex gap-2 flex-shrink-0">
                 <button
                   onClick={handleDownload}
                   className="btn-secondary btn-sm flex items-center gap-1 text-xs"

--- a/frontend/src/components/player/SkillProgressChart.tsx
+++ b/frontend/src/components/player/SkillProgressChart.tsx
@@ -2,6 +2,7 @@
 
 import { ProgressChart } from "./ProgressChart";
 import { Assessment } from "@/types/assessments";
+import { SkillCategory, getCategoryInfo } from "@/types/skills";
 
 interface SkillProgressChartProps {
   assessments: Assessment[];
@@ -38,9 +39,13 @@ export function SkillProgressChart({ assessments, skillName, category }: SkillPr
   }
 
   return (
-    <div className="card-base p-6">
-      <h3 className="text-lg font-semibold text-text-primary mb-4">
-        {skillName} Progress ({category})
+    <div className="card-base p-4 sm:p-6">
+      <h3 className="text-base sm:text-lg font-semibold text-text-primary mb-4">
+        {skillName}
+        <span className="text-text-secondary font-normal">
+          {" "}
+          &middot; {getCategoryInfo(category as SkillCategory)?.label ?? category}
+        </span>
       </h3>
       <ProgressChart 
         assessments={skillProgressData} 

--- a/frontend/src/types/assessments.ts
+++ b/frontend/src/types/assessments.ts
@@ -19,9 +19,15 @@ export interface Assessment {
   comments?: string;
   coachNotes?: string;
   isFinalized: boolean;
-  createdAt: string; // LocalDateTime as ISO string  
+  createdAt: string; // LocalDateTime as ISO string
   updatedAt: string; // LocalDateTime as ISO string
   skillScores: SkillScore[];
+  // Returned by the API but previously undeclared, so callers recomputed them
+  // by hand. Optional because create/update requests do not carry them.
+  overallAverage?: number;
+  categoryAverages?: Partial<Record<SkillCategory, number>>;
+  playerGroupName?: string;
+  totalSkillsAssessed?: number;
 }
 
 // Skill score within an assessment
@@ -149,6 +155,22 @@ export const getScoreLabel = (score: number): string => {
   if (score >= 4) return 'Needs Improvement';
   return 'Poor';
 };
+
+/**
+ * Background colour for a score bar, on the same 1-3 / 4-5 / 6-7 / 8-10 bands
+ * the coach sees when scoring. A parent reading the bar and the coach who
+ * entered it should be looking at the same colour language.
+ */
+export const getScoreBarColor = (score: number): string => {
+  if (score >= 8) return 'bg-accent-teal';
+  if (score >= 6) return 'bg-accent-yellow';
+  if (score >= 4) return 'bg-orange-500';
+  return 'bg-accent-red';
+};
+
+/** Scores are stored 1-10, so a percentage for bar widths is score * 10. */
+export const scoreToPercent = (score: number): number =>
+  Math.max(0, Math.min(100, score * 10));
 
 export const calculateAverageScore = (skillScores: SkillScore[]): number => {
   if (!skillScores.length) return 0;


### PR DESCRIPTION
## Correctness — the parent's assessment page was misreporting scores

Scores are stored 1–10 (`skill_scores_score_check CHECK (score >= 1 AND score <= 10)`), confirmed against the database and the live API. The parent's detail page disagreed in four places:

| Bug | Effect |
|---|---|
| `(skill.score / 10).toFixed(1)` | a score of **5 displayed as "0.5/10"** |
| `width: ${skill.score}%` | 5/10 drew a bar **5% full**, not 50% |
| radar fed `score / 10`, then divided again internally | every axis collapsed to a tenth |
| interface declared `category`; API sends `skillCategory` | every skill grouped under `undefined` → **one card headed "undefined"** instead of one per category |

`getOverallAverage` on the same page did *not* divide, so a parent saw "Overall Score 4.2/10" above a list of skills all reading 0.4/10 and 0.6/10. The player-facing copy of this page was already correct (`score * 10`%, raw scores to the radar) — only the parent's version was wrong.

Score-to-percent and bar colour now live in one place (`getScoreBarColor`, `scoreToPercent`), on the same 1-3/4-5/6-7/8-10 bands the coach sees when scoring. Per-skill ↑/↓ now uses `improvement`, which the API already returned and the UI ignored.

## Dashboard — rebuilt around what a parent is actually there for

It gave four equal-sized tiles to **Level, Group, Member Since, assessment count** — administrative facts — while the child's score sat in a small corner box. Reordered by what a parent asks:

1. the score, large, with its plain-English band and change since last time
2. **Doing well / Worth practising** — top and bottom three skills, the actionable part
3. score per area (Athletic / Technical / Mentality / Personality)
4. **the coach's written comments**, which the dashboard never displayed at all
5. trends over time
6. past assessments
7. Level / Group / Member since / count, demoted to one quiet row

Behaviour change: with exactly one assessment the old page showed "Need More Data" and **hid every score**. The breakdown now renders from the first assessment; only the trend chart waits for a second.

## By-skill picker

27 full-width cards, each repeating its category on its own line, all of which had to be scrolled past before the chart came into view on a phone. Replaced with one grouped `<select>` (`optgroup` per category, platform `select-base` styling) carrying each skill's current score and movement — `Speed 30m — 6/10 (+4)` — and opening on the biggest mover so the chart is never empty. Native picker on mobile.

## Responsive

- **Nutrition hero** never stacked: the heading block took `flex-1` and pushed "Download PDF" past the edge of the screen. Now stacks and goes full-width on phones.
- Its PDF embed was pinned at **1400px tall** — several screens of scrolling before anything else was reachable. Now viewport-relative.
- **Assessments list** had zero breakpoints: filter tabs now wrap, cards stack and truncate.
- Assessment detail header now wraps.

Swept the rest of the platform for the same class of bug: tables all have scroll containers, canvas charts scale via `w-full`/`max-width`, no fixed pixel widths escape their containers. Coach and manager pages use `grid-cols-1 md:*` and stack correctly.

## Verification

- `tsc --noEmit` clean; `npm run build` succeeds
- lint: 0 errors, 190 warnings — all pre-existing, none in the changed files
- Checked the rendered data against the live API: headline 4.2/10, **+1.6** since last time, 27 skills across 4 optgroups, opening on Coachable (+5)
- Reviewed locally by the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KSHwAZjB9qU97EFgCSh4M