### PR TITLE
Let admins hold back parent welcome emails, then send them together

### DIFF
--- a/backend/src/main/java/com/batal/config/WelcomeEmailExecutorConfig.java
+++ b/backend/src/main/java/com/batal/config/WelcomeEmailExecutorConfig.java
@@ -1,0 +1,50 @@
+package com.batal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * The thread a bulk welcome email run happens on.
+ *
+ * Deliberately NOT driven by {@code @EnableAsync}. EmailService already carries
+ * {@code @Async} annotations that are inert because nothing enables async
+ * anywhere in this application, and AuthService.issuePasswordSetupLink depends
+ * on that: it catches a delivery failure and returns false so the caller can
+ * log it and leave the token valid for a resend. Switching async on globally
+ * would move those failures onto another thread, the catch would stop being
+ * reachable, and every send would silently report success while marking the
+ * recipient as invited. So this executor is injected and used directly, and
+ * mail delivery stays synchronous on whatever thread calls it.
+ */
+@Configuration
+public class WelcomeEmailExecutorConfig {
+
+    public static final String WELCOME_EMAIL_EXECUTOR = "welcomeEmailExecutor";
+
+    /**
+     * One thread, so an intake's worth of mail goes out in sequence rather than
+     * opening a fistful of simultaneous SMTP connections. Each queued task is a
+     * whole run - one admin click - so the queue only needs to be deep enough
+     * to absorb impatient repeat clicks.
+     */
+    @Bean(name = WELCOME_EMAIL_EXECUTOR)
+    public ThreadPoolTaskExecutor welcomeEmailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("welcome-mail-");
+        // Runs the overflow on the caller instead of dropping it. Reaching this
+        // needs 50 queued runs, at which point making the admin wait is the
+        // right answer.
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        // Let an in-flight intake finish rather than cutting mail off mid-run.
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/batal/controller/SettingsController.java
+++ b/backend/src/main/java/com/batal/controller/SettingsController.java
@@ -1,0 +1,78 @@
+package com.batal.controller;
+
+import com.batal.dto.ParentWelcomeEmailSettingRequest;
+import com.batal.dto.ParentWelcomeEmailSettingResponse;
+import com.batal.entity.User;
+import com.batal.repository.UserRepository;
+import com.batal.service.SystemSettingService;
+import com.batal.service.ParentBulkEmailService;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Academy-wide settings an admin can change at runtime.
+ */
+@RestController
+@RequestMapping("/settings")
+@CrossOrigin(origins = "*", maxAge = 3600)
+public class SettingsController {
+
+    private static final Logger log = LoggerFactory.getLogger(SettingsController.class);
+
+    @Autowired
+    private SystemSettingService systemSettingService;
+
+    @Autowired
+    private ParentBulkEmailService parentBulkEmailService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // GET /api/settings/parent-welcome-emails
+    // Readable by managers too, so the parents list can explain why a newly
+    // created parent was not emailed.
+    @GetMapping("/parent-welcome-emails")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<ParentWelcomeEmailSettingResponse> getParentWelcomeEmailSetting() {
+        return ResponseEntity.ok(new ParentWelcomeEmailSettingResponse(
+                systemSettingService.isParentWelcomeEmailEnabled(),
+                parentBulkEmailService.countAwaitingWelcomeEmail()));
+    }
+
+    // PUT /api/settings/parent-welcome-emails
+    // Resuming does not send anything to the parents who were held back while
+    // it was paused - it only affects accounts created from now on. Those
+    // waiting are invited deliberately, from the parents list.
+    @PutMapping("/parent-welcome-emails")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ParentWelcomeEmailSettingResponse> updateParentWelcomeEmailSetting(
+            @Valid @RequestBody ParentWelcomeEmailSettingRequest request) {
+
+        Long adminId = currentUserId();
+        systemSettingService.setParentWelcomeEmailEnabled(request.getEnabled(), adminId);
+        log.info("Parent welcome emails {} by user {}",
+                request.getEnabled() ? "resumed" : "paused", adminId);
+
+        return ResponseEntity.ok(new ParentWelcomeEmailSettingResponse(
+                request.getEnabled(),
+                parentBulkEmailService.countAwaitingWelcomeEmail()));
+    }
+
+    /** Null rather than throwing: not knowing who flipped it is not a reason to refuse. */
+    private Long currentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            return null;
+        }
+        return userRepository.findByEmail(authentication.getName())
+                .map(User::getId)
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/com/batal/controller/UserController.java
+++ b/backend/src/main/java/com/batal/controller/UserController.java
@@ -7,9 +7,12 @@ import com.batal.dto.UserStatusUpdateRequest;
 import com.batal.dto.ChildSummaryDTO;
 import com.batal.dto.AssignChildRequest;
 import com.batal.dto.AdminPasswordResetRequest;
+import com.batal.dto.BulkWelcomeEmailRequest;
+import com.batal.dto.BulkWelcomeEmailResponse;
 import com.batal.entity.User;
 import com.batal.repository.UserRepository;
 import com.batal.service.UserService;
+import com.batal.service.ParentBulkEmailService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -37,7 +40,10 @@ public class UserController {
     
     @Autowired
     private UserRepository userRepository;
-    
+
+    @Autowired
+    private ParentBulkEmailService parentBulkEmailService;
+
     // GET /api/users - List all staff users (Admin only) with pagination and search
     @GetMapping
     @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
@@ -161,15 +167,63 @@ public class UserController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "firstName") String sortBy,
             @RequestParam(defaultValue = "asc") String sortDir,
-            @RequestParam(required = false) String search) {
+            @RequestParam(required = false) String search,
+            // Deactivated families are hidden unless explicitly asked for.
+            @RequestParam(defaultValue = "false") boolean includeInactive) {
 
         Sort sort = sortDir.equalsIgnoreCase("desc") ?
             Sort.by(sortBy).descending() :
             Sort.by(sortBy).ascending();
 
         Pageable pageable = PageRequest.of(page, size, sort);
-        Page<UserResponse> parents = userService.getAllParentUsers(pageable, search);
+        Page<UserResponse> parents = userService.getAllParentUsers(pageable, search, includeInactive);
         return ResponseEntity.ok(parents);
+    }
+
+    // GET /api/users/parents/deactivated-count - How many parents the default
+    // active-only view is hiding, so the Parents tab can offer to show them.
+    @GetMapping("/parents/deactivated-count")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<Map<String, Long>> getDeactivatedParentCount() {
+        Map<String, Long> response = new HashMap<>();
+        response.put("count", userService.countDeactivatedParents());
+        return ResponseEntity.ok(response);
+    }
+
+    // POST /api/users/parents/welcome-emails - Send the welcome (password setup)
+    // email to a chosen set of parents. This is how an intake created while
+    // welcome emails were paused finally gets invited.
+    @PostMapping("/parents/welcome-emails")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BulkWelcomeEmailResponse> sendParentWelcomeEmails(
+            @Valid @RequestBody BulkWelcomeEmailRequest request) {
+        BulkWelcomeEmailResponse response = parentBulkEmailService.sendWelcomeEmails(request.getUserIds());
+        return ResponseEntity.ok(response);
+    }
+
+    // POST /api/users/parents/password-resets - Send a password reset link to a
+    // chosen set of parents. For parents who already onboarded and are locked
+    // out; those who never set a password are skipped and need the welcome
+    // email instead.
+    @PostMapping("/parents/password-resets")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<BulkWelcomeEmailResponse> sendParentPasswordResets(
+            @Valid @RequestBody BulkWelcomeEmailRequest request) {
+        BulkWelcomeEmailResponse response = parentBulkEmailService.sendPasswordResets(request.getUserIds());
+        return ResponseEntity.ok(response);
+    }
+
+    // GET /api/users/parents/awaiting-welcome-email - Every parent who has an
+    // account but has never been sent their setup link. Backs the "waiting to
+    // be invited" count and the select-all action.
+    @GetMapping("/parents/awaiting-welcome-email")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('MANAGER')")
+    public ResponseEntity<Map<String, Object>> getParentsAwaitingWelcomeEmail() {
+        List<Long> ids = parentBulkEmailService.findIdsAwaitingWelcomeEmail();
+        Map<String, Object> response = new HashMap<>();
+        response.put("count", ids.size());
+        response.put("userIds", ids);
+        return ResponseEntity.ok(response);
     }
 
     // POST /api/users/{id}/reset-password - Admin sets a user's password directly

--- a/backend/src/main/java/com/batal/dto/BulkWelcomeEmailRequest.java
+++ b/backend/src/main/java/com/batal/dto/BulkWelcomeEmailRequest.java
@@ -1,0 +1,23 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Send the welcome (password setup) email to a chosen set of parents.
+ *
+ * The cap is a guard against a runaway selection turning into an unbounded
+ * mail run, not a limit the admin is meant to feel - it is well above the size
+ * of a single intake.
+ */
+public class BulkWelcomeEmailRequest {
+
+    @NotEmpty(message = "Select at least one parent")
+    @Size(max = 500, message = "At most 500 welcome emails can be sent at once")
+    private List<Long> userIds;
+
+    public List<Long> getUserIds() { return userIds; }
+    public void setUserIds(List<Long> userIds) { this.userIds = userIds; }
+}

--- a/backend/src/main/java/com/batal/dto/BulkWelcomeEmailResponse.java
+++ b/backend/src/main/java/com/batal/dto/BulkWelcomeEmailResponse.java
@@ -1,0 +1,53 @@
+package com.batal.dto;
+
+import java.util.List;
+
+/**
+ * What happened to a bulk welcome email request.
+ *
+ * Delivery runs in the background, so {@code queuedCount} is a count of
+ * accepted work, not of delivered mail. Skips are decided up front and are
+ * final. Progress shows up in the parents list, where anyone still marked as
+ * awaiting an invitation can simply be selected again.
+ */
+public class BulkWelcomeEmailResponse {
+
+    private int queuedCount;
+    private List<SkippedRecipient> skipped;
+
+    public BulkWelcomeEmailResponse() {}
+
+    public BulkWelcomeEmailResponse(int queuedCount, List<SkippedRecipient> skipped) {
+        this.queuedCount = queuedCount;
+        this.skipped = skipped;
+    }
+
+    public static class SkippedRecipient {
+        private Long userId;
+        private String name;
+        private String reason;
+
+        public SkippedRecipient() {}
+
+        public SkippedRecipient(Long userId, String name, String reason) {
+            this.userId = userId;
+            this.name = name;
+            this.reason = reason;
+        }
+
+        public Long getUserId() { return userId; }
+        public void setUserId(Long userId) { this.userId = userId; }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getReason() { return reason; }
+        public void setReason(String reason) { this.reason = reason; }
+    }
+
+    public int getQueuedCount() { return queuedCount; }
+    public void setQueuedCount(int queuedCount) { this.queuedCount = queuedCount; }
+
+    public List<SkippedRecipient> getSkipped() { return skipped; }
+    public void setSkipped(List<SkippedRecipient> skipped) { this.skipped = skipped; }
+}

--- a/backend/src/main/java/com/batal/dto/ParentWelcomeEmailSettingRequest.java
+++ b/backend/src/main/java/com/batal/dto/ParentWelcomeEmailSettingRequest.java
@@ -1,0 +1,12 @@
+package com.batal.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class ParentWelcomeEmailSettingRequest {
+
+    @NotNull(message = "enabled is required")
+    private Boolean enabled;
+
+    public Boolean getEnabled() { return enabled; }
+    public void setEnabled(Boolean enabled) { this.enabled = enabled; }
+}

--- a/backend/src/main/java/com/batal/dto/ParentWelcomeEmailSettingResponse.java
+++ b/backend/src/main/java/com/batal/dto/ParentWelcomeEmailSettingResponse.java
@@ -1,0 +1,27 @@
+package com.batal.dto;
+
+/**
+ * The state of the parent welcome email switch, plus how many parents are
+ * currently held back by it. The count is what makes a paused switch
+ * actionable rather than just off.
+ */
+public class ParentWelcomeEmailSettingResponse {
+
+    private boolean enabled;
+    private long awaitingWelcomeEmailCount;
+
+    public ParentWelcomeEmailSettingResponse() {}
+
+    public ParentWelcomeEmailSettingResponse(boolean enabled, long awaitingWelcomeEmailCount) {
+        this.enabled = enabled;
+        this.awaitingWelcomeEmailCount = awaitingWelcomeEmailCount;
+    }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public long getAwaitingWelcomeEmailCount() { return awaitingWelcomeEmailCount; }
+    public void setAwaitingWelcomeEmailCount(long awaitingWelcomeEmailCount) {
+        this.awaitingWelcomeEmailCount = awaitingWelcomeEmailCount;
+    }
+}

--- a/backend/src/main/java/com/batal/dto/UserResponse.java
+++ b/backend/src/main/java/com/batal/dto/UserResponse.java
@@ -33,6 +33,10 @@ public class UserResponse {
     // from creation, so this - not isActive - is what tells you whether someone
     // can actually log in yet.
     private LocalDateTime passwordSetAt;
+    // Null means this person has never been sent their setup link - either the
+    // account was created while welcome emails were paused, or every send so
+    // far failed. Either way they are waiting to be invited.
+    private LocalDateTime welcomeEmailSentAt;
     private List<String> roles;
     private List<ChildSummaryDTO> children; // For PARENT user type
 
@@ -59,6 +63,7 @@ public class UserResponse {
         this.createdAt = user.getCreatedAt();
         this.updatedAt = user.getUpdatedAt();
         this.passwordSetAt = user.getPasswordSetAt();
+        this.welcomeEmailSentAt = user.getPasswordSetupEmailLastSentAt();
         this.roles = roles;
     }
     
@@ -207,7 +212,16 @@ public class UserResponse {
     public void setPasswordSetAt(LocalDateTime passwordSetAt) {
         this.passwordSetAt = passwordSetAt;
     }
-    
+
+    public LocalDateTime getWelcomeEmailSentAt() {
+        return welcomeEmailSentAt;
+    }
+
+    public void setWelcomeEmailSentAt(LocalDateTime welcomeEmailSentAt) {
+        this.welcomeEmailSentAt = welcomeEmailSentAt;
+    }
+
+
     public List<String> getRoles() {
         return roles;
     }

--- a/backend/src/main/java/com/batal/entity/SystemSetting.java
+++ b/backend/src/main/java/com/batal/entity/SystemSetting.java
@@ -1,0 +1,42 @@
+package com.batal.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+/**
+ * One academy-wide switch, stored as text and parsed by
+ * {@link com.batal.service.SystemSettingService}.
+ *
+ * The key is the primary key, so a setting cannot be written twice and reading
+ * one never depends on ordering.
+ */
+@Entity
+@Table(name = "system_settings")
+@Getter
+@Setter
+@NoArgsConstructor
+public class SystemSetting {
+
+    @Id
+    @Column(name = "setting_key", length = 100)
+    private String key;
+
+    @Column(name = "setting_value", nullable = false, length = 500)
+    private String value;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    /** Admin who last changed this. Null for a seeded default. */
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    public SystemSetting(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/com/batal/repository/SystemSettingRepository.java
+++ b/backend/src/main/java/com/batal/repository/SystemSettingRepository.java
@@ -1,0 +1,13 @@
+package com.batal.repository;
+
+import com.batal.entity.SystemSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SystemSettingRepository extends JpaRepository<SystemSetting, String> {
+
+    Optional<SystemSetting> findByKey(String key);
+}

--- a/backend/src/main/java/com/batal/repository/UserRepository.java
+++ b/backend/src/main/java/com/batal/repository/UserRepository.java
@@ -70,4 +70,39 @@ public interface UserRepository extends JpaRepository<User, Long> {
            "OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :search, '%')))")
     Page<User> findParentUsersWithSearch(@Param("search") String search, Pageable pageable);
 
+    // Active-only counterparts. The Parents tab hides deactivated families by
+    // default - they are kept for history, not for day to day work - and shows
+    // them on request.
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.roles WHERE u.userType = 'PARENT' " +
+           "AND u.isActive = true")
+    Page<User> findActiveParentUsers(Pageable pageable);
+
+    @Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.roles WHERE u.userType = 'PARENT' " +
+           "AND u.isActive = true " +
+           "AND (LOWER(u.firstName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "OR LOWER(u.lastName) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "OR LOWER(u.email) LIKE LOWER(CONCAT('%', :search, '%')) " +
+           "OR LOWER(CONCAT(u.firstName, ' ', u.lastName)) LIKE LOWER(CONCAT('%', :search, '%')))")
+    Page<User> findActiveParentUsersWithSearch(@Param("search") String search, Pageable pageable);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.userType = 'PARENT' AND u.isActive = false")
+    long countDeactivatedParents();
+
+    // ========== WELCOME EMAIL QUERIES ==========
+
+    /**
+     * Parents who have never been sent their setup link. Accounts created while
+     * welcome emails were paused land here, and so do sends that failed - in
+     * both cases the parent is still waiting, so both should be re-sendable.
+     * Anyone who already set a password is excluded: they are past onboarding.
+     */
+    @Query("SELECT u FROM User u WHERE u.userType = 'PARENT' " +
+           "AND u.passwordSetupEmailLastSentAt IS NULL AND u.passwordSetAt IS NULL " +
+           "ORDER BY u.createdAt ASC")
+    List<User> findParentsAwaitingWelcomeEmail();
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.userType = 'PARENT' " +
+           "AND u.passwordSetupEmailLastSentAt IS NULL AND u.passwordSetAt IS NULL")
+    long countParentsAwaitingWelcomeEmail();
+
 }

--- a/backend/src/main/java/com/batal/service/AuthService.java
+++ b/backend/src/main/java/com/batal/service/AuthService.java
@@ -455,6 +455,53 @@ public class AuthService {
     }
 
     /**
+     * Issue a password reset link on an admin's behalf, keeping a mail failure
+     * from taking the token with it.
+     *
+     * The admin-facing counterpart to {@link #initiatePasswordReset}, which is
+     * public and therefore deliberately silent about who does or does not
+     * exist. An admin picking people off a list already knows they exist, so
+     * this reports back instead: false means the mail did not go out.
+     *
+     * Mirrors {@link #issuePasswordSetupLink} - REQUIRES_NEW, and the mailer is
+     * called inside a try/catch so a dead SMTP server cannot mark the
+     * transaction rollback-only and lose the token with it.
+     *
+     * @return true when the email was accepted for delivery
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean issuePasswordResetLink(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User", userId));
+
+        // Someone who never set a password has nothing to reset; they need the
+        // welcome/setup link instead.
+        if (user.getPasswordSetAt() == null) {
+            throw new BusinessRuleException("User has not set a password yet");
+        }
+
+        tokenRepository.invalidateAllUserTokensByType(user.getId(), TokenType.RESET, LocalDateTime.now());
+
+        String tokenString = generateSecureToken();
+        PasswordSetupToken token = new PasswordSetupToken();
+        token.setUser(user);
+        token.setToken(tokenString);
+        token.setTokenType(TokenType.RESET);
+        token.setExpiresAt(LocalDateTime.now().plusHours(tokenExpiryHours));
+        tokenRepository.save(token);
+
+        try {
+            emailService.sendPasswordResetEmail(user, tokenString);
+        } catch (RuntimeException e) {
+            // Swallowed so this transaction is not poisoned. The caller logs
+            // it; the token stays valid for a resend.
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Reset password using reset token
      */
     @Transactional

--- a/backend/src/main/java/com/batal/service/ParentBulkEmailService.java
+++ b/backend/src/main/java/com/batal/service/ParentBulkEmailService.java
@@ -1,0 +1,184 @@
+package com.batal.service;
+
+import com.batal.config.WelcomeEmailExecutorConfig;
+import com.batal.dto.BulkWelcomeEmailResponse;
+import com.batal.entity.User;
+import com.batal.entity.enums.UserType;
+import com.batal.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Sends email to a selected set of parents in bulk.
+ *
+ * Two sends live here because they share everything that is awkward: the
+ * eligibility rules, the background thread, and the "some of them will fail"
+ * reporting.
+ *
+ * - Welcome emails carry the password setup link. This is how accounts created
+ *   while welcome emails were paused eventually get invited: the admin waits
+ *   until the academy has something worth logging in to see, selects the
+ *   parents, and sends the whole intake at once.
+ * - Password resets are for parents who already onboarded and are locked out.
+ *
+ * The two are mutually exclusive by definition - setting a password is exactly
+ * what moves a parent from one group to the other - so each send skips the
+ * parents belonging to the other.
+ */
+@Service
+public class ParentBulkEmailService {
+
+    private static final Logger log = LoggerFactory.getLogger(ParentBulkEmailService.class);
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    @Qualifier(WelcomeEmailExecutorConfig.WELCOME_EMAIL_EXECUTOR)
+    private ThreadPoolTaskExecutor welcomeEmailExecutor;
+
+    /**
+     * Work out who can actually be mailed, then hand the sending to a
+     * background thread.
+     *
+     * Delivery is not awaited on purpose. Mail is sent synchronously by
+     * EmailService, one SMTP round trip per recipient with a five second
+     * timeout each, so a hundred parents could hold an HTTP request open for
+     * minutes and time out behind the proxy - having sent some unknown prefix
+     * of the list. Returning as soon as the work is accepted keeps the request
+     * fast, and the result is visible in the parents list either way: a
+     * successful send stamps the parent as invited, and a failed one leaves
+     * them awaiting an invitation so the admin can just select them again.
+     */
+    @Transactional(readOnly = true)
+    public BulkWelcomeEmailResponse sendWelcomeEmails(List<Long> userIds) {
+        // Already onboarded parents are skipped: re-sending would invite
+        // someone who is already using the system. They want a reset instead.
+        return dispatch(userIds, "Welcome email",
+                user -> user.getPasswordSetAt() != null ? "Already set their password" : null,
+                authService::issuePasswordSetupLink);
+    }
+
+    /**
+     * Send a password reset link to parents who are locked out.
+     *
+     * The mirror image of the welcome send: this one is for parents who already
+     * set a password, so anyone who has not yet is skipped - a reset link would
+     * be useless to them, and the welcome email is what they actually need.
+     */
+    @Transactional(readOnly = true)
+    public BulkWelcomeEmailResponse sendPasswordResets(List<Long> userIds) {
+        return dispatch(userIds, "Password reset",
+                user -> user.getPasswordSetAt() == null
+                        ? "Has not set a password yet - send the welcome email instead"
+                        : null,
+                authService::issuePasswordResetLink);
+    }
+
+    /**
+     * Decide who is eligible, then hand the sending to a background thread.
+     *
+     * @param extraSkipReason returns why this parent is ineligible, or null if they are fine
+     * @param send            issues the link for one user; false means the mail did not go out
+     */
+    private BulkWelcomeEmailResponse dispatch(
+            List<Long> userIds,
+            String kind,
+            java.util.function.Function<User, String> extraSkipReason,
+            java.util.function.Predicate<Long> send) {
+
+        // The same parent selected twice must not be mailed twice.
+        List<Long> uniqueIds = new ArrayList<>(new LinkedHashSet<>(userIds));
+
+        List<Long> toSend = new ArrayList<>();
+        List<BulkWelcomeEmailResponse.SkippedRecipient> skipped = new ArrayList<>();
+
+        for (Long userId : uniqueIds) {
+            User user = userRepository.findById(userId).orElse(null);
+
+            if (user == null) {
+                skipped.add(new BulkWelcomeEmailResponse.SkippedRecipient(
+                        userId, "Unknown user", "This account no longer exists"));
+                continue;
+            }
+
+            String name = user.getFullName();
+
+            if (user.getUserType() != UserType.PARENT) {
+                skipped.add(new BulkWelcomeEmailResponse.SkippedRecipient(
+                        userId, name, "Not a parent account"));
+                continue;
+            }
+
+            String reason = extraSkipReason.apply(user);
+            if (reason != null) {
+                skipped.add(new BulkWelcomeEmailResponse.SkippedRecipient(userId, name, reason));
+                continue;
+            }
+
+            toSend.add(userId);
+        }
+
+        if (!toSend.isEmpty()) {
+            welcomeEmailExecutor.execute(() -> deliver(toSend, kind, send));
+        }
+
+        return new BulkWelcomeEmailResponse(toSend.size(), skipped);
+    }
+
+    /**
+     * Runs off the request thread. Each recipient is sent independently so one
+     * bad address cannot stop the rest of the run.
+     */
+    private void deliver(List<Long> userIds, String kind, java.util.function.Predicate<Long> send) {
+        int sent = 0;
+        int failed = 0;
+
+        for (Long userId : userIds) {
+            try {
+                // Each send opens its own transaction and swallows a delivery
+                // failure rather than poisoning it, returning false instead.
+                if (send.test(userId)) {
+                    sent++;
+                } else {
+                    failed++;
+                    log.error("{} to user {} was not delivered. The account and its link are "
+                            + "fine, and the parent can be selected again.", kind, userId);
+                }
+            } catch (Exception e) {
+                failed++;
+                log.error("{} to user {} failed. The parent can be selected again.",
+                        kind, userId, e);
+            }
+        }
+
+        log.info("Bulk {} run finished: {} sent, {} failed, {} requested",
+                kind.toLowerCase(), sent, failed, userIds.size());
+    }
+
+    /** Parents who have an account but have never been sent their setup link. */
+    @Transactional(readOnly = true)
+    public long countAwaitingWelcomeEmail() {
+        return userRepository.countParentsAwaitingWelcomeEmail();
+    }
+
+    /** Ids of every parent still awaiting an invitation, for "select all". */
+    @Transactional(readOnly = true)
+    public List<Long> findIdsAwaitingWelcomeEmail() {
+        return userRepository.findParentsAwaitingWelcomeEmail().stream()
+                .map(User::getId)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/batal/service/SystemSettingService.java
+++ b/backend/src/main/java/com/batal/service/SystemSettingService.java
@@ -1,0 +1,61 @@
+package com.batal.service;
+
+import com.batal.entity.SystemSetting;
+import com.batal.repository.SystemSettingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+/**
+ * Reads and writes the academy-wide switches in {@code system_settings}.
+ */
+@Service
+public class SystemSettingService {
+
+    /**
+     * When false, creating a PARENT account does not send its welcome email.
+     * The account is still created and the admin sends the invitations later,
+     * in bulk, from the parents list.
+     *
+     * Scoped to parents on purpose: staff accounts are created one at a time by
+     * someone who wants that person logging in now, so they always get the mail.
+     */
+    public static final String PARENT_WELCOME_EMAILS_ENABLED = "parent_welcome_emails_enabled";
+
+    @Autowired
+    private SystemSettingRepository settingRepository;
+
+    /**
+     * Missing rows read as the default rather than throwing, so a settings row
+     * that was never seeded cannot stop accounts from being created.
+     */
+    @Transactional(readOnly = true)
+    public boolean getBoolean(String key, boolean defaultValue) {
+        return settingRepository.findByKey(key)
+                .map(setting -> Boolean.parseBoolean(setting.getValue()))
+                .orElse(defaultValue);
+    }
+
+    @Transactional
+    public void setBoolean(String key, boolean value, Long updatedBy) {
+        SystemSetting setting = settingRepository.findByKey(key)
+                .orElseGet(() -> new SystemSetting(key, String.valueOf(value)));
+        setting.setValue(String.valueOf(value));
+        setting.setUpdatedAt(LocalDateTime.now());
+        setting.setUpdatedBy(updatedBy);
+        settingRepository.save(setting);
+    }
+
+    /** Defaults to true so a missing row keeps the pre-existing behaviour. */
+    @Transactional(readOnly = true)
+    public boolean isParentWelcomeEmailEnabled() {
+        return getBoolean(PARENT_WELCOME_EMAILS_ENABLED, true);
+    }
+
+    @Transactional
+    public void setParentWelcomeEmailEnabled(boolean enabled, Long updatedBy) {
+        setBoolean(PARENT_WELCOME_EMAILS_ENABLED, enabled, updatedBy);
+    }
+}

--- a/backend/src/main/java/com/batal/service/UserService.java
+++ b/backend/src/main/java/com/batal/service/UserService.java
@@ -60,6 +60,9 @@ public class UserService {
     private AuthService authService;
 
     @Autowired
+    private SystemSettingService systemSettingService;
+
+    @Autowired
     private ApplicationEventPublisher eventPublisher;
 
 
@@ -77,15 +80,31 @@ public class UserService {
     }
 
     // Get parent users with pagination and search, each with their children.
-    public Page<UserResponse> getAllParentUsers(Pageable pageable, String search) {
+    //
+    // Deactivated families are excluded unless asked for. They are kept for
+    // history rather than day to day work, and filtering in the query - not in
+    // the page afterwards - is what keeps paging and totals honest.
+    public Page<UserResponse> getAllParentUsers(Pageable pageable, String search, boolean includeInactive) {
         Page<User> users;
-        if (search != null && !search.trim().isEmpty()) {
-            users = userRepository.findParentUsersWithSearch(search.trim(), pageable);
+        boolean searching = search != null && !search.trim().isEmpty();
+
+        if (searching) {
+            String term = search.trim();
+            users = includeInactive
+                    ? userRepository.findParentUsersWithSearch(term, pageable)
+                    : userRepository.findActiveParentUsersWithSearch(term, pageable);
         } else {
-            users = userRepository.findParentUsers(pageable);
+            users = includeInactive
+                    ? userRepository.findParentUsers(pageable)
+                    : userRepository.findActiveParentUsers(pageable);
         }
 
         return users.map(this::toUserResponseWithChildren);
+    }
+
+    /** How many parent accounts are hidden by the default active-only view. */
+    public long countDeactivatedParents() {
+        return userRepository.countDeactivatedParents();
     }
 
     /**
@@ -242,7 +261,16 @@ public class UserService {
 
         // Sent after this transaction commits. Calling it inline would let a
         // mail failure mark the transaction rollback-only and lose the account.
-        eventPublisher.publishEvent(new PasswordSetupEmailRequestedEvent(savedUser.getId()));
+        //
+        // Parents are held back while welcome emails are paused: during an
+        // intake the academy is still empty, and an invitation to an empty
+        // dashboard is a worse first impression than no invitation at all. The
+        // account is complete either way - only the email waits, and an admin
+        // sends the held-back ones in bulk from the parents list. Staff are
+        // never held back; whoever created that account wants them logging in.
+        if (shouldSendWelcomeEmailNow(savedUser)) {
+            eventPublisher.publishEvent(new PasswordSetupEmailRequestedEvent(savedUser.getId()));
+        }
 
         List<String> roleNames = savedUser.getRoles().stream()
                 .map(role -> role.getName())
@@ -250,6 +278,18 @@ public class UserService {
         return new UserResponse(savedUser, roleNames);
     }
     
+    /**
+     * Whether a freshly created account's welcome email goes out immediately.
+     * Only PARENT accounts can be held back, and only while an admin has
+     * paused parent welcome emails.
+     */
+    private boolean shouldSendWelcomeEmailNow(User user) {
+        if (user.getUserType() != UserType.PARENT) {
+            return true;
+        }
+        return systemSettingService.isParentWelcomeEmailEnabled();
+    }
+
     // Update user
     public UserResponse updateUser(Long id, UserUpdateRequest request) {
         User user = userRepository.findByIdWithRoles(id)

--- a/backend/src/main/resources/db/migration/V50__Create_system_settings.sql
+++ b/backend/src/main/resources/db/migration/V50__Create_system_settings.sql
@@ -1,0 +1,20 @@
+-- Academy-wide switches an admin can flip at runtime, without a redeploy.
+--
+-- Deliberately key/value rather than one column per switch: these are rare,
+-- unrelated toggles, and a new one should not cost a migration.
+
+CREATE TABLE system_settings (
+    setting_key   VARCHAR(100) PRIMARY KEY,
+    setting_value VARCHAR(500) NOT NULL,
+    updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by    BIGINT       REFERENCES users(id) ON DELETE SET NULL
+);
+
+COMMENT ON TABLE system_settings IS 'Runtime academy-wide settings, keyed by name. Values are stored as text and parsed by SystemSettingService.';
+COMMENT ON COLUMN system_settings.updated_by IS 'Admin who last changed the value. Null if the row is a seeded default or that admin has since been deleted.';
+
+-- Seeded ON so deploying this migration changes nothing about how the academy
+-- already behaves. An admin pauses it from the dashboard before a bulk intake,
+-- then resumes once there is something worth logging in to see.
+INSERT INTO system_settings (setting_key, setting_value)
+VALUES ('parent_welcome_emails_enabled', 'true');

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -26,17 +26,20 @@ import ProtectedRoute from '@/components/ProtectedRoute';
 import LogoutButton from '@/components/LogoutButton';
 import { useAuth } from '@/store/hooks';
 import { useNotification } from '@/contexts/NotificationContext';
-import { groupsAPI, usersAPI, playersAPI, authAPI } from '@/lib/api';
+import { groupsAPI, usersAPI, playersAPI, authAPI, settingsAPI } from '@/lib/api';
 import {
   GroupResponse,
   UserResponse,
   PlayerDTO,
   UserType,
-  Level
+  Level,
+  ParentWelcomeEmailSetting,
+  BulkWelcomeEmailResponse,
+  getParentInviteStatus
 } from '@/types';
 
 
-const ADMIN_TABS = ['overview', 'groups', 'users', 'parents', 'players', 'assessments', 'skills'] as const;
+const ADMIN_TABS = ['overview', 'groups', 'users', 'parents', 'players', 'assessments', 'skills', 'settings'] as const;
 type AdminTab = (typeof ADMIN_TABS)[number];
 
 /** The tab named in the URL hash, or Overview when it is missing or unknown. */
@@ -103,6 +106,25 @@ export default function AdminDashboard() {
     sortDir: 'asc',
     search: ''
   });
+
+  // Welcome email state for the Parents tab.
+  //
+  // While welcomeEmailsEnabled is false, new parent accounts are created
+  // without their setup email - which is the point during an intake, when the
+  // academy is still empty and an invitation would lead somewhere with nothing
+  // in it. Those parents accumulate as "not invited" and are sent their
+  // invitations here, together, once there is something worth seeing.
+  const [welcomeEmailSetting, setWelcomeEmailSetting] = useState<ParentWelcomeEmailSetting | null>(null);
+  const [isSavingWelcomeEmailSetting, setIsSavingWelcomeEmailSetting] = useState(false);
+  const [selectedParentIds, setSelectedParentIds] = useState<Set<number>>(new Set());
+  const [isSendingWelcomeEmails, setIsSendingWelcomeEmails] = useState(false);
+  const [isSendingPasswordResets, setIsSendingPasswordResets] = useState(false);
+
+  // Deactivated families are kept for history, not day to day work, so the
+  // Parents tab hides them until asked. The count is what makes the hidden
+  // ones discoverable instead of just absent.
+  const [showDeactivatedParents, setShowDeactivatedParents] = useState(false);
+  const [deactivatedParentCount, setDeactivatedParentCount] = useState(0);
 
   const [playersPagination, setPlayersPagination] = useState({
     page: 0,
@@ -189,6 +211,7 @@ export default function AdminDashboard() {
   useEffect(() => {
     loadDashboardData();
   }, []);
+
 
   const loadDashboardData = async () => {
     setLoading(true);
@@ -292,15 +315,20 @@ export default function AdminDashboard() {
 
   const loadParentsData = useCallback(async () => {
     try {
-      const response = await usersAPI.getParents(
-        parentsPagination.page,
-        parentsPagination.size,
-        parentsPagination.sortBy,
-        parentsPagination.sortDir,
-        parentsPagination.search || undefined
-      );
+      const [response, deactivated] = await Promise.all([
+        usersAPI.getParents(
+          parentsPagination.page,
+          parentsPagination.size,
+          parentsPagination.sortBy,
+          parentsPagination.sortDir,
+          parentsPagination.search || undefined,
+          showDeactivatedParents
+        ),
+        usersAPI.getDeactivatedParentCount(),
+      ]);
 
       setParents(response.content);
+      setDeactivatedParentCount(deactivated.count);
       setParentsPagination(prev => ({
         ...prev,
         totalElements: response.totalElements,
@@ -310,7 +338,7 @@ export default function AdminDashboard() {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load parents data';
       showError(errorMessage, 'Parents Data Error');
     }
-  }, [parentsPagination.page, parentsPagination.size, parentsPagination.sortBy, parentsPagination.sortDir, parentsPagination.search, showError]);
+  }, [parentsPagination.page, parentsPagination.size, parentsPagination.sortBy, parentsPagination.sortDir, parentsPagination.search, showDeactivatedParents, showError]);
 
   const loadPlayersData = useCallback(async () => {
     try {
@@ -581,11 +609,169 @@ export default function AdminDashboard() {
   const handleResendSetupEmail = async (userId: number) => {
     try {
       const user = findAccountById(userId);
-      const response = await authAPI.resendSetupEmail(userId);
+      await authAPI.resendSetupEmail(userId);
       showSuccess(`Password setup email sent to ${user?.email || 'user'}`);
+      // The card's badge and the waiting count both hang off this send, so
+      // refresh them rather than leaving the parent looking uninvited.
+      await Promise.all([loadParentsData(), loadWelcomeEmailSetting()]);
     } catch (error: any) {
       showError(error.message || 'Failed to send password setup email');
     }
+  };
+
+  // ===== Parent welcome emails =====
+
+  const loadWelcomeEmailSetting = useCallback(async () => {
+    try {
+      setWelcomeEmailSetting(await settingsAPI.getParentWelcomeEmails());
+    } catch (error) {
+      // Not worth an error toast: the switch is secondary to the list, and the
+      // panel simply stays hidden until a later load succeeds.
+      console.error('Failed to load the parent welcome email setting', error);
+    }
+  }, []);
+
+  // Refetched on entering either tab that shows it, so the waiting count is
+  // current even if parents were added from elsewhere since the dashboard
+  // loaded.
+  useEffect(() => {
+    if (activeTab === 'parents' || activeTab === 'settings') {
+      loadWelcomeEmailSetting();
+    }
+  }, [activeTab, loadWelcomeEmailSetting]);
+
+  const handleToggleWelcomeEmails = async (enabled: boolean) => {
+    setIsSavingWelcomeEmailSetting(true);
+    try {
+      const updated = await settingsAPI.setParentWelcomeEmails(enabled);
+      setWelcomeEmailSetting(updated);
+      showSuccess(
+        enabled
+          ? 'Welcome emails resumed. New parents will be emailed as soon as their account is created.'
+          : 'Welcome emails paused. New parents will be created quietly until you resume.'
+      );
+    } catch (error: any) {
+      showError(error.message || 'Failed to update the welcome email setting');
+    } finally {
+      setIsSavingWelcomeEmailSetting(false);
+    }
+  };
+
+  const toggleParentSelection = (userId: number) => {
+    setSelectedParentIds(prev => {
+      const next = new Set(prev);
+      if (next.has(userId)) {
+        next.delete(userId);
+      } else {
+        next.add(userId);
+      }
+      return next;
+    });
+  };
+
+  /** Parents on this page who have not been invited yet. */
+  const uninvitedOnPage = parents.filter(p => getParentInviteStatus(p) === 'not_invited');
+
+  const selectAllUninvitedOnPage = () => {
+    setSelectedParentIds(prev => {
+      const next = new Set(prev);
+      uninvitedOnPage.forEach(p => next.add(p.id));
+      return next;
+    });
+  };
+
+  /**
+   * Select every parent still awaiting an invitation, not just the ones on
+   * screen. The ids come from the server because an intake will usually run to
+   * several pages, and "select all" that quietly meant "this page" would send a
+   * fraction of the intake and look like it had sent all of it.
+   */
+  const selectAllUninvitedEverywhere = async () => {
+    try {
+      const { userIds } = await usersAPI.getParentsAwaitingWelcomeEmail();
+      setSelectedParentIds(new Set(userIds));
+      if (userIds.length === 0) {
+        showSuccess('Every parent has already been invited.');
+      }
+    } catch (error: any) {
+      showError(error.message || 'Failed to look up parents awaiting an invitation');
+    }
+  };
+
+  /**
+   * Shared by both bulk sends. Delivery happens in the background, so this
+   * refetches once immediately for the quick ones and again shortly after for
+   * the rest; anything that genuinely failed keeps its old state and can
+   * simply be selected again.
+   */
+  const runBulkSend = async (
+    send: (ids: number[]) => Promise<BulkWelcomeEmailResponse>,
+    setBusy: (busy: boolean) => void,
+    successNote: (count: number) => string,
+    failureLabel: string
+  ) => {
+    const userIds = Array.from(selectedParentIds);
+    if (userIds.length === 0) return;
+
+    setBusy(true);
+    try {
+      const result = await send(userIds);
+
+      if (result.queuedCount > 0) {
+        showSuccess(successNote(result.queuedCount));
+      }
+
+      if (result.skipped.length > 0) {
+        const detail = result.skipped
+          .slice(0, 3)
+          .map(s => `${s.name} (${s.reason.toLowerCase()})`)
+          .join(', ');
+        const more = result.skipped.length > 3 ? ` and ${result.skipped.length - 3} more` : '';
+        showError(
+          `Skipped ${result.skipped.length} of ${userIds.length}: ${detail}${more}`,
+          'Some parents were not emailed'
+        );
+      }
+
+      setSelectedParentIds(new Set());
+
+      await Promise.all([loadParentsData(), loadWelcomeEmailSetting()]);
+      setTimeout(() => {
+        loadParentsData();
+        loadWelcomeEmailSetting();
+      }, 4000);
+    } catch (error: any) {
+      showError(error.message || failureLabel);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSendWelcomeEmails = () =>
+    runBulkSend(
+      usersAPI.sendParentWelcomeEmails,
+      setIsSendingWelcomeEmails,
+      (n) =>
+        `Sending welcome emails to ${n} parent${n === 1 ? '' : 's'}. ` +
+        'They will show as invited here as the emails go out.',
+      'Failed to send welcome emails'
+    );
+
+  const handleSendPasswordResets = () =>
+    runBulkSend(
+      usersAPI.sendParentPasswordResets,
+      setIsSendingPasswordResets,
+      (n) =>
+        `Sending a password reset link to ${n} parent${n === 1 ? '' : 's'}. ` +
+        'The link is valid for 48 hours.',
+      'Failed to send password resets'
+    );
+
+  const handleToggleDeactivatedParents = () => {
+    // Back to the first page: the row the admin is looking at will not be in
+    // the same position once the hidden families are folded in.
+    setShowDeactivatedParents(prev => !prev);
+    setParentsPagination(prev => ({ ...prev, page: 0 }));
   };
 
   // Delete handlers
@@ -988,7 +1174,8 @@ export default function AdminDashboard() {
             { id: 'parents', label: 'Parents', icon: <span>👪</span> },
             { id: 'players', label: 'Players', icon: <span>⚽</span> },
             { id: 'assessments', label: 'Assessments', icon: <span>📝</span> },
-            { id: 'skills', label: 'Skills', icon: <span>🎯</span> }
+            { id: 'skills', label: 'Skills', icon: <span>🎯</span> },
+            { id: 'settings', label: 'Settings', icon: <span>⚙️</span> }
           ]}
           activeTab={activeTab}
           onChange={(tabId) => setActiveTab(tabId as AdminTab)}
@@ -1195,6 +1382,48 @@ export default function AdminDashboard() {
                 </button>
               </div>
 
+              {/* A paused switch is worth surfacing here even though it now
+                  lives in Settings: without it, parents created on this screen
+                  silently do not get emailed and nothing on screen says why. */}
+              {welcomeEmailSetting && !welcomeEmailSetting.enabled && (
+                <div className="mb-6 rounded-lg border border-orange-500/30 bg-orange-500/10 p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                  <p className="text-xs text-text-secondary">
+                    <span className="font-semibold text-orange-400">Welcome emails are paused.</span>{' '}
+                    New parents are created quietly, and
+                    {welcomeEmailSetting.awaitingWelcomeEmailCount > 0 ? (
+                      <>
+                        {' '}
+                        <span className="font-semibold text-text-primary">
+                          {welcomeEmailSetting.awaitingWelcomeEmailCount}
+                        </span>{' '}
+                        {welcomeEmailSetting.awaitingWelcomeEmailCount === 1 ? 'is' : 'are'} waiting to be
+                        invited. Select them below and send when you are ready.
+                      </>
+                    ) : (
+                      ' nothing is sent until you invite them.'
+                    )}
+                  </p>
+                  <div className="flex items-center gap-3 shrink-0">
+                    {welcomeEmailSetting.awaitingWelcomeEmailCount > 0 && (
+                      <button
+                        type="button"
+                        onClick={selectAllUninvitedEverywhere}
+                        className="text-xs font-medium text-primary hover:underline"
+                      >
+                        Select all waiting
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setActiveTab('settings')}
+                      className="text-xs font-medium text-text-secondary hover:underline"
+                    >
+                      Settings
+                    </button>
+                  </div>
+                </div>
+              )}
+
               {/* Search Bar */}
               <div className="mb-6">
                 <div className="relative">
@@ -1215,6 +1444,26 @@ export default function AdminDashboard() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                   </svg>
                 </div>
+
+                {/* Deactivated families are hidden by default. The control only
+                    appears when there are some, so it never implies hidden
+                    records that do not exist. */}
+                {(deactivatedParentCount > 0 || showDeactivatedParents) && (
+                  <div className="mt-2 flex items-center gap-2">
+                    <span className="text-xs text-text-secondary">
+                      {showDeactivatedParents
+                        ? 'Showing deactivated parents'
+                        : `${deactivatedParentCount} deactivated parent${deactivatedParentCount === 1 ? '' : 's'} hidden`}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleToggleDeactivatedParents}
+                      className="text-xs font-medium text-primary hover:underline"
+                    >
+                      {showDeactivatedParents ? 'Hide them' : 'Show them'}
+                    </button>
+                  </div>
+                )}
               </div>
 
               {parents.length === 0 ? (
@@ -1224,23 +1473,93 @@ export default function AdminDashboard() {
                     : 'No parents yet. Add a player to create the first one.'}
                 </div>
               ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                  {parents.map((parent) => (
-                    <UserCard
-                      key={parent.id}
-                      user={parent}
-                      onEdit={handleEditParent}
-                      onDelete={handleDeleteUser}
-                      onDeactivate={(userId) => handleUserStatusUpdate(userId, false, 'Deactivated by admin')}
-                      onActivate={(userId) => handleUserStatusUpdate(userId, true)}
-                      onAddPlayer={handleAddPlayerForParent}
-                      onUnassignChild={handleUnassignChild}
-                      onResendSetupEmail={handleResendSetupEmail}
-                      onResetPassword={(userId) => setResetPasswordModal({ isOpen: true, userId })}
-                      showActions={true}
-                    />
-                  ))}
-                </div>
+                <>
+                  {/* Selection bar. Selection is kept across pages on purpose,
+                      so "Select all waiting" can span an intake that runs to
+                      several pages; the count is always shown so a selection
+                      reaching beyond this page is never invisible. */}
+                  <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3 bg-secondary-50 rounded-lg">
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <span className="text-sm text-text-primary font-medium">
+                        {selectedParentIds.size > 0
+                          ? `${selectedParentIds.size} selected`
+                          : 'Select parents to send their welcome email'}
+                      </span>
+
+                      {uninvitedOnPage.length > 0 && (
+                        <button
+                          type="button"
+                          onClick={selectAllUninvitedOnPage}
+                          className="text-xs font-medium text-primary hover:underline"
+                        >
+                          Select {uninvitedOnPage.length} not invited on this page
+                        </button>
+                      )}
+
+                      {selectedParentIds.size > 0 && (
+                        <button
+                          type="button"
+                          onClick={() => setSelectedParentIds(new Set())}
+                          className="text-xs font-medium text-text-secondary hover:underline"
+                        >
+                          Clear
+                        </button>
+                      )}
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+                      {/* Two sends, because a selected parent is in exactly one
+                          of two states: never onboarded (needs the welcome
+                          email) or onboarded and locked out (needs a reset).
+                          Each send skips the other group and says so. */}
+                      {/* btn-primary / btn-secondary rather than hand-rolled
+                          colours: --text-primary is near-black, so putting it
+                          on the dark blue --primary makes the label invisible.
+                          The shared classes already pair white with it. */}
+                      <button
+                        type="button"
+                        onClick={handleSendWelcomeEmails}
+                        disabled={selectedParentIds.size === 0 || isSendingWelcomeEmails || isSendingPasswordResets}
+                        className="btn-primary btn-sm w-full sm:w-auto disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        {isSendingWelcomeEmails
+                          ? 'Sending...'
+                          : `Send welcome email${selectedParentIds.size === 1 ? '' : 's'}`}
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={handleSendPasswordResets}
+                        disabled={selectedParentIds.size === 0 || isSendingWelcomeEmails || isSendingPasswordResets}
+                        title="For parents who already set a password and cannot get back in"
+                        className="btn-secondary btn-sm w-full sm:w-auto disabled:opacity-40 disabled:cursor-not-allowed"
+                      >
+                        {isSendingPasswordResets ? 'Sending...' : 'Send password reset'}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {parents.map((parent) => (
+                      <UserCard
+                        key={parent.id}
+                        user={parent}
+                        onEdit={handleEditParent}
+                        onDelete={handleDeleteUser}
+                        onDeactivate={(userId) => handleUserStatusUpdate(userId, false, 'Deactivated by admin')}
+                        onActivate={(userId) => handleUserStatusUpdate(userId, true)}
+                        onAddPlayer={handleAddPlayerForParent}
+                        onUnassignChild={handleUnassignChild}
+                        onResendSetupEmail={handleResendSetupEmail}
+                        onResetPassword={(userId) => setResetPasswordModal({ isOpen: true, userId })}
+                        showActions={true}
+                        isSelectable={true}
+                        isSelected={selectedParentIds.has(parent.id)}
+                        onSelect={toggleParentSelection}
+                      />
+                    ))}
+                  </div>
+                </>
               )}
 
               {/* Pagination Controls */}
@@ -1383,6 +1702,95 @@ export default function AdminDashboard() {
 
           {activeTab === 'skills' && (
             <SkillsManagement />
+          )}
+
+          {activeTab === 'settings' && (
+            <div>
+              <div className="mb-6">
+                <h2 className="text-lg sm:text-xl font-semibold text-text-primary">Settings</h2>
+                <p className="text-xs text-text-secondary mt-1">
+                  Academy-wide settings. Changes take effect immediately.
+                </p>
+              </div>
+
+              <section>
+                <h3 className="text-sm font-semibold text-text-primary mb-1">Communications</h3>
+                <p className="text-xs text-text-secondary mb-4">
+                  Control the automatic emails the system sends on your behalf.
+                </p>
+
+                {welcomeEmailSetting ? (
+                  <div
+                    className={`rounded-lg border p-4 ${
+                      welcomeEmailSetting.enabled
+                        ? 'bg-secondary-50 border-border'
+                        : 'bg-orange-500/10 border-orange-500/30'
+                    }`}
+                  >
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <h4 className="text-sm font-semibold text-text-primary">
+                            Parent welcome emails
+                          </h4>
+                          <span
+                            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                              welcomeEmailSetting.enabled
+                                ? 'bg-accent-teal/20 text-accent-teal border border-accent-teal/30'
+                                : 'bg-orange-500/20 text-orange-400 border border-orange-500/30'
+                            }`}
+                          >
+                            {welcomeEmailSetting.enabled ? 'Sending' : 'Paused'}
+                          </span>
+                        </div>
+                        <p className="text-xs text-text-secondary mt-1 max-w-2xl">
+                          {welcomeEmailSetting.enabled
+                            ? 'New parents are emailed their password setup link as soon as their account is created.'
+                            : 'New parents are created quietly. Pause this while you are loading the academy in, so nobody is invited to an empty dashboard.'}
+                        </p>
+                      </div>
+
+                      <button
+                        type="button"
+                        onClick={() => handleToggleWelcomeEmails(!welcomeEmailSetting.enabled)}
+                        disabled={isSavingWelcomeEmailSetting}
+                        className="btn-secondary btn-sm w-full sm:w-auto shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {isSavingWelcomeEmailSetting
+                          ? 'Saving...'
+                          : welcomeEmailSetting.enabled
+                            ? 'Pause welcome emails'
+                            : 'Resume welcome emails'}
+                      </button>
+                    </div>
+
+                    {welcomeEmailSetting.awaitingWelcomeEmailCount > 0 && (
+                      <div className="mt-3 pt-3 border-t border-border flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                        <p className="text-xs text-text-secondary">
+                          <span className="font-semibold text-text-primary">
+                            {welcomeEmailSetting.awaitingWelcomeEmailCount}
+                          </span>{' '}
+                          parent{welcomeEmailSetting.awaitingWelcomeEmailCount === 1 ? '' : 's'} waiting to be
+                          invited. Resuming does not email them — invite them deliberately from the
+                          Parents tab.
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => setActiveTab('parents')}
+                          className="shrink-0 text-xs font-medium text-primary hover:underline text-left sm:text-right"
+                        >
+                          Go to Parents
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-border bg-secondary-50 p-4 text-xs text-text-secondary">
+                    Could not load the communication settings. Refresh to try again.
+                  </div>
+                )}
+              </section>
+            </div>
           )}
         </div>
 

--- a/frontend/src/components/UserCard.tsx
+++ b/frontend/src/components/UserCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from 'react';
-import { UserResponse, UserType } from '@/types/users';
+import { UserResponse, UserType, getParentInviteStatus } from '@/types/users';
 
 interface UserCardProps {
   user: UserResponse;
@@ -45,6 +45,7 @@ export default function UserCard({
   assignedGroupNames = []
 }: UserCardProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const inviteStatus = getParentInviteStatus(user);
 
   const getUserTypeColor = (userType?: UserType) => {
     switch (userType) {
@@ -91,6 +92,21 @@ export default function UserCard({
 
       {/* User Avatar & Info */}
       <div className="flex items-start space-x-4 mb-4">
+        {isSelectable && (
+          <div className="flex-shrink-0 pt-3">
+            {/* Stops propagation so the card's own click handler does not
+                toggle the selection a second time and undo this one. */}
+            <input
+              type="checkbox"
+              checked={isSelected}
+              onChange={() => onSelect?.(user.id)}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Select ${user.firstName} ${user.lastName}`}
+              className="w-5 h-5 rounded border-border bg-surface text-primary focus:ring-2 focus:ring-primary cursor-pointer"
+            />
+          </div>
+        )}
+
         <div className="flex-shrink-0">
           <div className={`w-12 h-12 bg-gradient-to-br ${getUserTypeColor(user.userType)} rounded-full flex items-center justify-center`}>
             <span className="text-white font-semibold text-lg">
@@ -98,7 +114,7 @@ export default function UserCard({
             </span>
           </div>
         </div>
-        
+
         <div className="flex-1 min-w-0">
           <h3 className="text-lg font-semibold text-text-primary truncate">
             {user.firstName} {user.lastName}
@@ -126,11 +142,22 @@ export default function UserCard({
             </div>
           )}
           {/* Accounts are active from creation, so "active" does not mean they
-              can sign in. This is what says whether they have set a password. */}
-          {!user.passwordSetAt && (
+              can sign in. These say how far through onboarding someone is.
+              "Not invited" and "Pending setup" are kept apart because they need
+              different things: the first is waiting on the academy to send the
+              email, the second is waiting on the account holder to act on it. */}
+          {inviteStatus === 'not_invited' && (
+            <div
+              className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-orange-500/20 text-orange-400 border border-orange-500/30"
+              title="No welcome email has been sent yet, so this person does not know the account exists"
+            >
+              Not invited
+            </div>
+          )}
+          {inviteStatus === 'invited' && (
             <div
               className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-500/20 text-accent-yellow border border-yellow-500/30"
-              title="This account has not set a password yet and cannot sign in"
+              title="Welcome email sent, but they have not set a password yet so they cannot sign in"
             >
               Pending setup
             </div>
@@ -143,7 +170,7 @@ export default function UserCard({
         <div className="mb-4">
           <div className="bg-primary/20 border border-primary/30 rounded-lg p-3">
             <div className="flex items-center gap-2 mb-1">
-              <svg className="w-4 h-4 text-primary" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="w-3 h-3 text-primary" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M6 6V5a3 3 0 013-3h2a3 3 0 013 3v1h2a2 2 0 012 2v3.57A22.952 22.952 0 0110 13a22.95 22.95 0 01-8-1.43V8a2 2 0 012-2h2zm2-1a1 1 0 011-1h2a1 1 0 011 1v1H8V5zm1 5a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clipRule="evenodd" />
                 <path d="M2 13.692V16a2 2 0 002 2h12a2 2 0 002-2v-2.308A24.974 24.974 0 0110 15c-2.796 0-5.487-.46-8-1.308z" />
               </svg>
@@ -169,7 +196,7 @@ export default function UserCard({
           <div className="bg-blue-500/20 border border-blue-500/30 rounded-lg p-3">
             <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-3 h-3 text-blue-400" fill="currentColor" viewBox="0 0 20 20">
                   <path d="M9 6a3 3 0 11-6 0 3 3 0 016 0zM17 6a3 3 0 11-6 0 3 3 0 016 0zM12.93 17c.046-.327.07-.66.07-1a6.97 6.97 0 00-1.5-4.33A5 5 0 0119 16v1h-6.07zM6 11a5 5 0 015 5v1H1v-1a5 5 0 015-5z" />
                 </svg>
                 <span className="text-sm font-medium text-blue-400">
@@ -212,7 +239,7 @@ export default function UserCard({
                         className="text-red-400 hover:text-red-300 transition-colors"
                         title="Remove child"
                       >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                         </svg>
                       </button>
@@ -231,7 +258,7 @@ export default function UserCard({
       {user.roles && user.roles.length > 0 && (
         <div className="mb-4">
           <div className="flex items-center text-primary mb-2">
-            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-3 h-3 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clipRule="evenodd" />
             </svg>
             <span className="text-sm font-medium">Roles</span>
@@ -253,7 +280,7 @@ export default function UserCard({
       {user.title && (
         <div className="mb-4">
           <div className="flex items-center text-primary mb-1">
-            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-3 h-3 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-6-3a2 2 0 11-4 0 2 2 0 014 0zm-2 4a5 5 0 00-4.546 2.916A5.986 5.986 0 0010 16a5.986 5.986 0 004.546-2.084A5 5 0 0010 11z" clipRule="evenodd" />
             </svg>
             <span className="text-sm font-medium">Title</span>
@@ -266,7 +293,7 @@ export default function UserCard({
       {user.createdAt && (
         <div className="mb-4">
           <div className="flex items-center text-primary mb-1">
-            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-3 h-3 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clipRule="evenodd" />
             </svg>
             <span className="text-sm font-medium">Joined</span>
@@ -291,7 +318,7 @@ export default function UserCard({
       {/* Actions */}
       {showActions && (
         <div className={`
-          flex gap-2 mt-6 transition-opacity duration-200
+          flex flex-wrap gap-1.5 mt-6 transition-opacity duration-200
           ${isHovered ? 'opacity-100' : 'opacity-70'}
         `}>
           {onViewDetails && (
@@ -300,7 +327,7 @@ export default function UserCard({
                 e.stopPropagation();
                 onViewDetails(user.id);
               }}
-              className="btn-outline btn-sm flex-1"
+              className="btn-outline btn-xs flex-1 whitespace-nowrap"
             >
               View Details
             </button>
@@ -312,13 +339,17 @@ export default function UserCard({
                 e.stopPropagation();
                 onResendSetupEmail(user.id);
               }}
-              className="btn-primary btn-sm"
-              title="Resend password setup email"
+              className="btn-primary btn-xs whitespace-nowrap"
+              title={
+                inviteStatus === 'not_invited'
+                  ? 'Send the welcome email with their password setup link'
+                  : 'Resend password setup email'
+              }
             >
-              <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
               </svg>
-              Resend Email
+              {inviteStatus === 'not_invited' ? 'Send Invite' : 'Resend Email'}
             </button>
           )}
 
@@ -328,9 +359,9 @@ export default function UserCard({
                 e.stopPropagation();
                 onEdit(user.id);
               }}
-              className="btn-secondary btn-sm"
+              className="btn-secondary btn-xs"
             >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                 <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
               </svg>
             </button>
@@ -342,7 +373,7 @@ export default function UserCard({
                 e.stopPropagation();
                 onResetPassword(user.id);
               }}
-              className="btn-secondary btn-sm"
+              className="btn-secondary btn-xs whitespace-nowrap"
               title="Set a new password for this user"
             >
               Reset Password
@@ -355,7 +386,7 @@ export default function UserCard({
                 e.stopPropagation();
                 onDeactivate(user.id);
               }}
-              className="btn-destructive btn-sm"
+              className="btn-destructive btn-xs whitespace-nowrap"
             >
               Deactivate
             </button>
@@ -367,7 +398,7 @@ export default function UserCard({
                 e.stopPropagation();
                 onActivate(user.id);
               }}
-              className="btn-success btn-sm"
+              className="btn-success btn-xs whitespace-nowrap"
             >
               Activate
             </button>
@@ -382,10 +413,10 @@ export default function UserCard({
                 }
               }}
               disabled={assignedGroupsCount > 0}
-              className={`btn-sm ${assignedGroupsCount > 0 ? 'btn-disabled' : 'btn-destructive'}`}
+              className={`btn-xs ${assignedGroupsCount > 0 ? 'btn-disabled' : 'btn-destructive'}`}
               title={assignedGroupsCount > 0 ? `Cannot delete: Coach is assigned to ${assignedGroupsCount} group(s)` : "Delete Coach"}
             >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
             </button>
@@ -397,7 +428,7 @@ export default function UserCard({
       {user.address && (
         <div className="mt-4 pt-4 border-t border-border">
           <div className="flex items-center text-primary mb-1">
-            <svg className="w-4 h-4 mr-2" fill="currentColor" viewBox="0 0 20 20">
+            <svg className="w-3 h-3 mr-1.5" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
             </svg>
             <span className="text-sm font-medium">Address</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5,6 +5,10 @@ import {
   LoginResponse,
   UserResponse,
 } from "@/types/auth";
+import {
+  BulkWelcomeEmailResponse,
+  ParentWelcomeEmailSetting,
+} from "@/types/users";
 import { CreatePlayersRequest, CreatePlayersResponse } from "@/types/players";
 import { GroupResponse } from "@/types/groups";
 import {
@@ -389,12 +393,14 @@ export const usersAPI = {
   },
 
   // Parents only. getAll returns academy staff and excludes them.
+  // Deactivated families are hidden unless includeInactive is set.
   getParents: async (
     page = 0,
     size = 10,
     sortBy = "firstName",
     sortDir = "asc",
-    search?: string
+    search?: string,
+    includeInactive = false
   ): Promise<{
     content: UserResponse[];
     totalElements: number;
@@ -413,7 +419,68 @@ export const usersAPI = {
       params.append("search", search);
     }
 
+    if (includeInactive) {
+      params.append("includeInactive", "true");
+    }
+
     return apiRequest(`/users/parents?${params.toString()}`);
+  },
+
+  // How many parents the default active-only view is hiding.
+  getDeactivatedParentCount: async (): Promise<{ count: number }> => {
+    return apiRequest("/users/parents/deactivated-count");
+  },
+
+  // Send the welcome (password setup) email to a set of parents. Resolves as
+  // soon as the backend accepts the work; delivery continues in the background,
+  // so refetch the parents list to watch them flip to "invited".
+  sendParentWelcomeEmails: async (
+    userIds: number[]
+  ): Promise<BulkWelcomeEmailResponse> => {
+    return apiRequest<BulkWelcomeEmailResponse>("/users/parents/welcome-emails", {
+      method: "POST",
+      body: JSON.stringify({ userIds }),
+    });
+  },
+
+  // Send a password reset link to parents who already onboarded and are locked
+  // out. Parents who never set a password are skipped - they need the welcome
+  // email instead, and the response says so.
+  sendParentPasswordResets: async (
+    userIds: number[]
+  ): Promise<BulkWelcomeEmailResponse> => {
+    return apiRequest<BulkWelcomeEmailResponse>("/users/parents/password-resets", {
+      method: "POST",
+      body: JSON.stringify({ userIds }),
+    });
+  },
+
+  // Every parent who has an account but has never been sent their setup link.
+  // Returns ids across all pages, so "select all waiting" is not limited to
+  // whichever page happens to be on screen.
+  getParentsAwaitingWelcomeEmail: async (): Promise<{
+    count: number;
+    userIds: number[];
+  }> => {
+    return apiRequest("/users/parents/awaiting-welcome-email");
+  },
+};
+
+// Academy-wide settings
+export const settingsAPI = {
+  getParentWelcomeEmails: async (): Promise<ParentWelcomeEmailSetting> => {
+    return apiRequest<ParentWelcomeEmailSetting>("/settings/parent-welcome-emails");
+  },
+
+  // Only affects parents created from now on. Parents already held back stay
+  // held back until an admin sends their invitations explicitly.
+  setParentWelcomeEmails: async (
+    enabled: boolean
+  ): Promise<ParentWelcomeEmailSetting> => {
+    return apiRequest<ParentWelcomeEmailSetting>("/settings/parent-welcome-emails", {
+      method: "PUT",
+      body: JSON.stringify({ enabled }),
+    });
   },
 };
 

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -48,8 +48,40 @@ export interface UserResponse {
   createdAt: string; // ISO datetime string
   updatedAt: string; // ISO datetime string
   passwordSetAt?: string; // ISO datetime string - when user first set their password
+  // Undefined means this person has never been sent their setup link - either
+  // the account was created while welcome emails were paused, or every send so
+  // far failed. Either way they are still waiting to be invited.
+  welcomeEmailSentAt?: string; // ISO datetime string
   roles: string[];
   children?: ChildSummaryDTO[]; // For PARENT user type
+}
+
+// Where a parent sits in onboarding. Derived from the two timestamps above
+// rather than stored, so it cannot drift out of step with them.
+export type ParentInviteStatus = "not_invited" | "invited" | "active";
+
+export function getParentInviteStatus(user: UserResponse): ParentInviteStatus {
+  if (user.passwordSetAt) return "active";
+  if (user.welcomeEmailSentAt) return "invited";
+  return "not_invited";
+}
+
+// Bulk welcome email send (matches backend BulkWelcomeEmailResponse.java).
+// queuedCount is work accepted, not mail delivered - sending happens in the
+// background, and progress shows up as parents flip to "invited" in the list.
+export interface BulkWelcomeEmailResponse {
+  queuedCount: number;
+  skipped: {
+    userId: number;
+    name: string;
+    reason: string;
+  }[];
+}
+
+// Parent welcome email switch (matches backend ParentWelcomeEmailSettingResponse.java)
+export interface ParentWelcomeEmailSetting {
+  enabled: boolean;
+  awaitingWelcomeEmailCount: number;
 }
 
 // User Create Request (matches backend UserCreateRequest.java)


### PR DESCRIPTION
## Why

Creating a parent account emails them a password setup link straight away. During an intake that is the wrong moment: the academy is still empty, and an invitation to a dashboard with nothing in it is a worse first impression than no invitation at all.

## What

A pause switch under **Settings → Communications**. While it is off, PARENT accounts are created without their welcome email and collect as **Not invited**; the admin selects them from the Parents tab and sends the whole intake at once, once there is something worth logging in to see.

Staff accounts are never held back — whoever created a coach or manager wants them signing in now.

**The switch seeds to ON, so merging this changes nothing until an admin turns it off.**

### Also in here

- Bulk **Send password reset** for parents who already onboarded and are locked out. The two sends are mirror images: each skips the other group and reports why.
- Deactivated parents hidden from the Parents tab by default, with a **Show them** toggle. Filtered in the query rather than after paging, so totals and page counts stay honest.
- The old "Pending setup" badge splits into **Not invited** (waiting on the academy) and **Pending setup** (waiting on the parent) — different problems needing different actions.
- Card action buttons to `btn-xs` + `whitespace-nowrap`; two-line labels were making every button double height.
- Bulk send buttons use `btn-primary`/`btn-secondary`. Hand-rolled colours put near-black `--text-primary` on dark blue `--primary`, making the label invisible.

## The one design decision worth reviewing

Bulk sending runs on **its own executor, deliberately not `@EnableAsync`**.

`EmailService` already carries `@Async` annotations that are inert because nothing enables async anywhere in the app, and `AuthService.issuePasswordSetupLink` depends on that: it catches a delivery failure and returns `false` so the caller can log it and leave the token valid for a resend. Switching async on globally would move those failures onto another thread, make the catch unreachable, and have every send silently report success while marking the recipient as invited.

Delivery is also not awaited. Mail is synchronous — one SMTP round trip per recipient at a 5s timeout — so a hundred parents in one request would hang for minutes and time out behind the proxy having sent an unknown prefix of the list. The endpoint returns as soon as the work is accepted; a successful send stamps the parent as invited, and a failed one leaves them as "Not invited" so they can simply be selected again.

## Migration

`V50__Create_system_settings.sql` — a key/value settings table, seeded with the switch ON.

## Testing

- Backend: `mvnw test` green (6 tests). V50 applies cleanly.
- Frontend: `tsc --noEmit` clean, lint 0 errors, production build succeeds.
- End-to-end against a local SMTP sink: no mail while paused; staff still emailed; parent appears in the waiting list; bulk send delivers a real setup link and flips the badge; resume emails immediately; duplicate ids send once; reset email uses the reset template and skips un-onboarded parents; hidden parents excluded from `totalElements` (10 vs 13); non-admin gets 403 on both new endpoints; empty selection 400s.
- UI walkthrough driven in a real browser across every step above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)